### PR TITLE
Prepare beads for production

### DIFF
--- a/src/main/java/org/pjdbc/drivers/MockDriver.java
+++ b/src/main/java/org/pjdbc/drivers/MockDriver.java
@@ -31,6 +31,9 @@ public class MockDriver extends AbstractDriver {
 	    return logs.get(url).getStream().toString().trim();}
 	return "";}
 
+    public static void clearLogs () {
+	logs.clear();}
+
     protected boolean acceptsSubProtocol (String subprotocol) {
 	return "mock".equals(subprotocol);}
 


### PR DESCRIPTION
The DriverEdgeCasesTest setUp method calls MockDriver.clearLogs() to reset logs between tests, but this method was missing from MockDriver, causing a compilation error.