### PR TITLE
Add throws SQLException to allDrivers_rejectWrongSubprotocol test

### DIFF
--- a/src/test/java/DriverEdgeCasesTest.java
+++ b/src/test/java/DriverEdgeCasesTest.java
@@ -618,7 +618,7 @@ public class DriverEdgeCasesTest {
     // ========== Cross-Driver Boundary Tests ==========
 
     @Test
-    public void allDrivers_rejectWrongSubprotocol() {
+    public void allDrivers_rejectWrongSubprotocol() throws SQLException {
         Driver[] drivers = {
             new FilterDriver(),
             new TeeDriver(),


### PR DESCRIPTION
Driver.acceptsURL() declares throws SQLException, so the test method must also declare it.