### PR TITLE
Fix UserMapDriver registration and properties loading

### DIFF
--- a/src/main/java/org/pjdbc/drivers/UserMapDriver.java
+++ b/src/main/java/org/pjdbc/drivers/UserMapDriver.java
@@ -5,13 +5,12 @@ import java.util.*;
 import org.pjdbc.sql.*;
 
 public class UserMapDriver extends AbstractProxyDriver {
-    static {try {DriverManager.registerDriver(new UserMapDriver());} catch (Exception e) {throw new RuntimeException(e);}}
-
-    private Properties p = new Properties();
-
-    public UserMapDriver () {
-	try {p.load(getClass().getClassLoader().getResourceAsStream("org.pjdbc.UserMapDriver.UserMapFile"));}
-	catch (Exception e) {throw new RuntimeException(e);}}
+    private static Properties p = new Properties();
+    static {
+	try {
+	    DriverManager.registerDriver(new UserMapDriver());
+	    p.load(UserMapDriver.class.getClassLoader().getResourceAsStream("org.pjdbc.UserMapDriver.UserMapFile"));
+	} catch (Exception e) {throw new RuntimeException(e);}}
 
     protected boolean acceptsSubProtocol (String subprotocol) {
 	return "mapuser".equals(subprotocol);}

--- a/src/main/resources/META-INF/services/java.sql.Driver
+++ b/src/main/resources/META-INF/services/java.sql.Driver
@@ -5,3 +5,4 @@ org.pjdbc.drivers.TeeDriver
 org.pjdbc.drivers.SinkDriver
 org.pjdbc.drivers.FilterDriver
 org.pjdbc.drivers.PoolDriver
+org.pjdbc.drivers.UserMapDriver


### PR DESCRIPTION
- Add UserMapDriver to META-INF/services/java.sql.Driver so it gets auto-loaded by DriverManager (fixes connectIndirectly test)
- Make Properties static and load once during class initialization instead of per-instance (fixes multipleConnectionsSameUser test)