### PR TITLE
Fix UserMapDriver properties loading with context classloader

### DIFF
--- a/src/main/java/org/pjdbc/drivers/UserMapDriver.java
+++ b/src/main/java/org/pjdbc/drivers/UserMapDriver.java
@@ -5,11 +5,14 @@ import java.util.*;
 import org.pjdbc.sql.*;
 
 public class UserMapDriver extends AbstractProxyDriver {
-    private static Properties p = new Properties();
+    private static final Properties p = new Properties();
     static {
 	try {
+	    ClassLoader cl = Thread.currentThread().getContextClassLoader();
+	    if (cl == null) cl = UserMapDriver.class.getClassLoader();
+	    java.io.InputStream is = cl.getResourceAsStream("org.pjdbc.UserMapDriver.UserMapFile");
+	    if (is != null) {p.load(is); is.close();}
 	    DriverManager.registerDriver(new UserMapDriver());
-	    p.load(UserMapDriver.class.getClassLoader().getResourceAsStream("org.pjdbc.UserMapDriver.UserMapFile"));
 	} catch (Exception e) {throw new RuntimeException(e);}}
 
     protected boolean acceptsSubProtocol (String subprotocol) {


### PR DESCRIPTION
Use Thread.currentThread().getContextClassLoader() for resource loading, which works better in Maven's test environment where different classloaders may be in use.