### PR TITLE
Fix UserMapDriver to not modify input Properties

### DIFF
--- a/src/main/java/org/pjdbc/drivers/UserMapDriver.java
+++ b/src/main/java/org/pjdbc/drivers/UserMapDriver.java
@@ -22,6 +22,8 @@ public class UserMapDriver extends AbstractProxyDriver {
 	if (!acceptsURL(url)) return null;
 	String user = info.getProperty("user");
 	String[] mapping = p.getProperty(user).split("/");
-	info.setProperty("user", mapping[0]);
-	info.setProperty("password", mapping[1]);
-	return DriverManager.getConnection(subname(url), info);}}
+	Properties delegateInfo = new Properties();
+	delegateInfo.putAll(info);
+	delegateInfo.setProperty("user", mapping[0]);
+	delegateInfo.setProperty("password", mapping[1]);
+	return DriverManager.getConnection(subname(url), delegateInfo);}}


### PR DESCRIPTION
The connect() method was modifying the caller's Properties object, changing the user from e.g. "alice" to "alice_db". This broke reuse of the same Properties for multiple connections. Now we copy the Properties before modifying, preserving the original.