### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Plaintext Credential Storage

### DIFF
--- a/src/main/java/org/pjdbc/drivers/UserMapDriver.java
+++ b/src/main/java/org/pjdbc/drivers/UserMapDriver.java
@@ -14,6 +14,11 @@ import org.pjdbc.sql.AbstractProxyDriver;
 /**
  * Maps application usernames to database credentials.
  *
+ * <p><strong>SECURITY WARNING: This driver is insecure as it stores credentials in plaintext.</strong>
+ * It is intended for legacy use cases or development environments only. For production,
+ * use a secure credential store such as HashiCorp Vault, AWS Secrets Manager, or your
+ * platform's equivalent. This driver is deprecated and will be removed in a future version.
+ *
  * <p>UserMapDriver enables multi-tenant or role-based database access by translating
  * application-level usernames to actual database credentials. This is useful for:
  * <ul>
@@ -44,7 +49,11 @@ import org.pjdbc.sql.AbstractProxyDriver;
  *
  * <p><strong>Security:</strong> Error messages are intentionally generic to prevent
  * user enumeration attacks. Missing users and invalid mappings produce the same error.
+ *
+ * @deprecated This driver is insecure and will be removed in a future version.
+ *             Use a secure credential store instead.
  */
+@Deprecated
 @DriverCapability(
     prefix = "mapuser",
     description = "Maps application usernames to database credentials",
@@ -57,6 +66,7 @@ public class UserMapDriver extends AbstractProxyDriver {
 
     static {
         try {
+            System.err.println("WARNING: PJDBC: UserMapDriver stores credentials in plaintext and is insecure. Use a secure credential store instead. This driver will be removed in a future version.");
             ClassLoader cl = Thread.currentThread().getContextClassLoader();
             if (cl == null) {
                 cl = UserMapDriver.class.getClassLoader();


### PR DESCRIPTION
🚨 **Severity:** CRITICAL

💡 **Vulnerability:** The `UserMapDriver` loads database credentials from a properties file in plaintext, exposing sensitive information.

🎯 **Impact:** An attacker with access to the properties file could gain direct access to the database.

🔧 **Fix:** Deprecated the `UserMapDriver` and added prominent warnings to the Javadoc and runtime logs to strongly discourage its use and inform developers of the security risk. A direct fix (e.g., encryption) would be a breaking change, so this provides the strongest possible mitigation without altering functionality.

✅ **Verification:**
- Ran tests for `UserMapDriver` to confirm no functionality was broken.
- Verified that the new security warning is logged to `System.err` during test execution.
- Ran the full unit test suite (`mvn test -Pfast`) to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [12955407139625669967](https://jules.google.com/task/12955407139625669967) started by @davidaventimiglia-professional*