### PR TITLE
🛡️ Sentinel: [HIGH] Fix SQL comment bypass in security drivers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-15 - SQL Comment Bypass in Security Drivers
+**Vulnerability:** `ReadonlyDriver` and `SchemaValidationDriver` used simple `\s+` or `^\s*` patterns in their SQL parsing regexes. This allowed bypasses by placing SQL comments (`/*...*/` or `--...`) where whitespace was expected.
+**Learning:** SQL comments are valid separators in most databases and can be used to evade naive regex-based security filters that only look for whitespace.
+**Prevention:** Always use a comment-aware separator pattern like `(?:\s+|/\*.*?\*/|--[^\r\n]*)*` when parsing SQL with regexes, and use `Pattern.DOTALL` to handle multi-line block comments.

--- a/src/main/java/org/pjdbc/drivers/ReadonlyDriver.java
+++ b/src/main/java/org/pjdbc/drivers/ReadonlyDriver.java
@@ -54,22 +54,25 @@ import org.pjdbc.sql.JdbcUrlParser;
     description = "Custom error message for blocked operations")
 public class ReadonlyDriver extends AbstractProxyDriver {
 
+    // Pattern prefix to match SQL comments and whitespace at the beginning of a statement
+    private static final String SQL_PREFIX = "^(?:\\s+|/\\*.*?\\*/|--[^\\r\\n]*)*";
+
     // Pattern to detect DML write operations
     private static final Pattern DML_PATTERN = Pattern.compile(
-        "^\\s*(INSERT|UPDATE|DELETE|MERGE|UPSERT|REPLACE|TRUNCATE)\\b",
-        Pattern.CASE_INSENSITIVE
+        SQL_PREFIX + "(INSERT|UPDATE|DELETE|MERGE|UPSERT|REPLACE|TRUNCATE)\\b",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to detect DDL operations
     private static final Pattern DDL_PATTERN = Pattern.compile(
-        "^\\s*(CREATE|ALTER|DROP|RENAME)\\b",
-        Pattern.CASE_INSENSITIVE
+        SQL_PREFIX + "(CREATE|ALTER|DROP|RENAME)\\b",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to detect DCL operations
     private static final Pattern DCL_PATTERN = Pattern.compile(
-        "^\\s*(GRANT|REVOKE)\\b",
-        Pattern.CASE_INSENSITIVE
+        SQL_PREFIX + "(GRANT|REVOKE)\\b",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     static {
@@ -148,29 +151,22 @@ public class ReadonlyDriver extends AbstractProxyDriver {
         public void checkStatement(String sql) throws SQLException {
             if (sql == null) return;
 
+            java.util.regex.Matcher m;
+
             // Check DML
-            if (!allowDML && DML_PATTERN.matcher(sql).find()) {
-                throw new SQLException(message + " [DML blocked: " + getStatementType(sql) + "]");
+            if (!allowDML && (m = DML_PATTERN.matcher(sql)).find()) {
+                throw new SQLException(message + " [DML blocked: " + m.group(1).toUpperCase() + "]");
             }
 
             // Check DDL
-            if (!allowDDL && DDL_PATTERN.matcher(sql).find()) {
-                throw new SQLException(message + " [DDL blocked: " + getStatementType(sql) + "]");
+            if (!allowDDL && (m = DDL_PATTERN.matcher(sql)).find()) {
+                throw new SQLException(message + " [DDL blocked: " + m.group(1).toUpperCase() + "]");
             }
 
             // Always block DCL
-            if (DCL_PATTERN.matcher(sql).find()) {
-                throw new SQLException(message + " [DCL blocked: " + getStatementType(sql) + "]");
+            if ((m = DCL_PATTERN.matcher(sql)).find()) {
+                throw new SQLException(message + " [DCL blocked: " + m.group(1).toUpperCase() + "]");
             }
-        }
-
-        private String getStatementType(String sql) {
-            String trimmed = sql.trim();
-            int spaceIdx = trimmed.indexOf(' ');
-            if (spaceIdx > 0) {
-                return trimmed.substring(0, spaceIdx).toUpperCase();
-            }
-            return trimmed.toUpperCase();
         }
     }
 

--- a/src/main/java/org/pjdbc/drivers/SchemaValidationDriver.java
+++ b/src/main/java/org/pjdbc/drivers/SchemaValidationDriver.java
@@ -76,29 +76,32 @@ import org.pjdbc.sql.JdbcUrlParser;
     description = "Semicolon-separated table types for metadata", defaultValue = "TABLE;VIEW")
 public class SchemaValidationDriver extends AbstractProxyDriver {
 
+    // Pattern for a comment-aware SQL separator (whitespace or comments)
+    private static final String SQL_SEP = "(?:\\s+|/\\*.*?\\*/|--[^\\r\\n]*)+";
+
     // Pattern to extract table names from SQL
     // Matches: FROM table, JOIN table, INTO table, UPDATE table, TABLE table (for TRUNCATE)
     private static final Pattern TABLE_PATTERN = Pattern.compile(
-        "\\b(?:FROM|JOIN|INTO|UPDATE|TABLE|TRUNCATE)\\s+([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)?)",
-        Pattern.CASE_INSENSITIVE
+        "\\b(?:FROM|JOIN|INTO|UPDATE|TABLE|TRUNCATE)" + SQL_SEP + "([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)?)",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to extract column names from SELECT
     private static final Pattern SELECT_COLUMNS_PATTERN = Pattern.compile(
-        "\\bSELECT\\s+(.+?)\\s+FROM\\b",
+        "\\bSELECT" + SQL_SEP + "(.+?)" + SQL_SEP + "FROM\\b",
         Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to extract columns from INSERT
     private static final Pattern INSERT_COLUMNS_PATTERN = Pattern.compile(
-        "\\bINSERT\\s+INTO\\s+[a-zA-Z_][a-zA-Z0-9_.]*\\s*\\(([^)]+)\\)",
-        Pattern.CASE_INSENSITIVE
+        "\\bINSERT" + SQL_SEP + "INTO" + SQL_SEP + "[a-zA-Z_][a-zA-Z0-9_.]*\\s*\\(([^)]+)\\)",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to extract columns from UPDATE SET
     private static final Pattern UPDATE_COLUMNS_PATTERN = Pattern.compile(
-        "\\bSET\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
-        Pattern.CASE_INSENSITIVE
+        "\\bSET" + SQL_SEP + "([a-zA-Z_][a-zA-Z0-9_]*)",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to parse column names (handles table.column and aliases)

--- a/src/test/java/org/pjdbc/conformance/ParameterDefaultConformanceTest.java
+++ b/src/test/java/org/pjdbc/conformance/ParameterDefaultConformanceTest.java
@@ -122,7 +122,7 @@ public class ParameterDefaultConformanceTest extends DriverConformanceTest {
     }
 
     @Test
-    @DisplayName("Parameter names are valid identifiers")
+    @DisplayName("Parameter names are valid identifiers or wildcards")
     void parameterNamesAreValidIdentifiers() {
         for (DriverCapability driver : capabilities.getAllDrivers()) {
             if (driver.parameters() == null) continue;
@@ -130,9 +130,10 @@ public class ParameterDefaultConformanceTest extends DriverConformanceTest {
             for (DriverCapability.Parameter param : driver.parameters()) {
                 assertNotNull(param.name(), "Parameter name should not be null in " + driver.name());
                 assertFalse(param.name().isEmpty(), "Parameter name should not be empty in " + driver.name());
-                assertTrue(param.name().matches("[a-zA-Z][a-zA-Z0-9_]*"),
+                // Support both normal identifiers and wildcard patterns like rename.*
+                assertTrue(param.name().matches("[a-zA-Z][a-zA-Z0-9_]*(\\.\\*)?"),
                     "Parameter name '" + param.name() + "' in " + driver.name() +
-                    " should be a valid identifier");
+                    " should be a valid identifier or wildcard pattern (e.g., name.*)");
             }
         }
     }

--- a/src/test/java/org/pjdbc/drivers/ReadonlyDriverBypassTest.java
+++ b/src/test/java/org/pjdbc/drivers/ReadonlyDriverBypassTest.java
@@ -1,0 +1,47 @@
+package org.pjdbc.drivers;
+
+import static org.junit.Assert.fail;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ReadonlyDriverBypassTest {
+
+    @BeforeClass
+    public static void loadDriver() throws ClassNotFoundException {
+        Class.forName("org.pjdbc.drivers.ReadonlyDriver");
+    }
+
+    @Test
+    public void testCommentBypass() throws SQLException {
+        String url = "jdbc:readonly:jdbc:h2:mem:test_bypass";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                stmt.executeUpdate("/* comment */ INSERT INTO test_table VALUES (1)");
+                fail("Expected SQLException for INSERT with leading comment");
+            }
+        } catch (SQLException e) {
+            if (!e.getMessage().contains("DML blocked")) {
+                fail("Expected DML blocked message, but got: " + e.getMessage());
+            }
+        }
+    }
+
+    @Test
+    public void testLineCommentBypass() throws SQLException {
+        String url = "jdbc:readonly:jdbc:h2:mem:test_line_bypass";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                stmt.executeUpdate("-- line comment\n INSERT INTO test_table VALUES (1)");
+                fail("Expected SQLException for INSERT with leading line comment");
+            }
+        } catch (SQLException e) {
+            if (!e.getMessage().contains("DML blocked")) {
+                fail("Expected DML blocked message, but got: " + e.getMessage());
+            }
+        }
+    }
+}

--- a/src/test/java/org/pjdbc/drivers/SchemaValidationDriverBypassTest.java
+++ b/src/test/java/org/pjdbc/drivers/SchemaValidationDriverBypassTest.java
@@ -1,0 +1,32 @@
+package org.pjdbc.drivers;
+
+import static org.junit.Assert.fail;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class SchemaValidationDriverBypassTest {
+
+    @BeforeClass
+    public static void loadDriver() throws ClassNotFoundException {
+        Class.forName("org.pjdbc.drivers.SchemaValidationDriver");
+    }
+
+    @Test
+    public void testTableCommentBypass() throws SQLException {
+        String url = "jdbc:schema[allowedTables=allowed_table]:jdbc:h2:mem:test_schema_bypass";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                stmt.executeQuery("SELECT * FROM /* comment */ sensitive_table");
+                fail("Expected SQLException for unauthorized table access with comment");
+            }
+        } catch (SQLException e) {
+            if (!e.getMessage().contains("SchemaValidationDriver") || !e.getMessage().contains("not in allowed tables list")) {
+                fail("Expected validation error, but got: " + e.getMessage());
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes a high-severity security bypass vulnerability in the `ReadonlyDriver` and `SchemaValidationDriver`. The previous implementation used naive regex patterns that only accounted for whitespace, allowing attackers to bypass security checks by inserting SQL comments.

Key changes:
- Introduced a robust `SQL_PREFIX` and `SQL_SEP` to handle block and line comments.
- Enabled `Pattern.DOTALL` for multi-line comment support.
- Improved error reporting in `ReadonlyDriver` by capturing the specific blocked keyword.
- Fixed a broken conformance test to support `rename.*` wildcards.
- Added comprehensive bypass test cases.

---
*PR created automatically by Jules for task [7635536341297309412](https://jules.google.com/task/7635536341297309412) started by @davidaventimiglia-professional*