### PR TITLE
🛡️ Sentinel: [HIGH] Fix SQL comment bypass in security drivers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-16 - SQL Comment Bypass in Regex Parsing
+**Vulnerability:** Security-sensitive drivers (ReadonlyDriver, SchemaValidationDriver) using simple `\s+` or `^\s*` regex patterns for SQL keyword detection were bypassable by using SQL comments (e.g., `/* comment */ INSERT` or `INSERT/**/INTO`).
+**Learning:** Standard Java regex `\s` does not match SQL comments. Attackers can exploit this to hide keywords from security filters while still having them executed by the underlying database.
+**Prevention:** Use a centralized, robust `SqlPatterns` utility that explicitly handles whitespace, block comments, and line comments. Always use `Pattern.DOTALL` when matching SQL that might contain multi-line comments.

--- a/src/main/java/org/pjdbc/drivers/ReadonlyDriver.java
+++ b/src/main/java/org/pjdbc/drivers/ReadonlyDriver.java
@@ -11,6 +11,7 @@ import java.sql.Statement;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
+import org.pjdbc.sql.SqlPatterns;
 import org.pjdbc.annotations.DriverCapability;
 import org.pjdbc.annotations.DriverParameter;
 import org.pjdbc.annotations.DriverParameter.ParameterType;
@@ -56,20 +57,20 @@ public class ReadonlyDriver extends AbstractProxyDriver {
 
     // Pattern to detect DML write operations
     private static final Pattern DML_PATTERN = Pattern.compile(
-        "^\\s*(INSERT|UPDATE|DELETE|MERGE|UPSERT|REPLACE|TRUNCATE)\\b",
-        Pattern.CASE_INSENSITIVE
+        SqlPatterns.SQL_PREFIX + "(INSERT|UPDATE|DELETE|MERGE|UPSERT|REPLACE|TRUNCATE)\\b",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to detect DDL operations
     private static final Pattern DDL_PATTERN = Pattern.compile(
-        "^\\s*(CREATE|ALTER|DROP|RENAME)\\b",
-        Pattern.CASE_INSENSITIVE
+        SqlPatterns.SQL_PREFIX + "(CREATE|ALTER|DROP|RENAME)\\b",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to detect DCL operations
     private static final Pattern DCL_PATTERN = Pattern.compile(
-        "^\\s*(GRANT|REVOKE)\\b",
-        Pattern.CASE_INSENSITIVE
+        SqlPatterns.SQL_PREFIX + "(GRANT|REVOKE)\\b",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     static {

--- a/src/main/java/org/pjdbc/drivers/SchemaValidationDriver.java
+++ b/src/main/java/org/pjdbc/drivers/SchemaValidationDriver.java
@@ -18,6 +18,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.pjdbc.sql.SqlPatterns;
 import org.pjdbc.annotations.DriverCapability;
 import org.pjdbc.annotations.DriverParameter;
 import org.pjdbc.annotations.DriverParameter.ParameterType;
@@ -79,26 +80,26 @@ public class SchemaValidationDriver extends AbstractProxyDriver {
     // Pattern to extract table names from SQL
     // Matches: FROM table, JOIN table, INTO table, UPDATE table, TABLE table (for TRUNCATE)
     private static final Pattern TABLE_PATTERN = Pattern.compile(
-        "\\b(?:FROM|JOIN|INTO|UPDATE|TABLE|TRUNCATE)\\s+([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)?)",
-        Pattern.CASE_INSENSITIVE
+        "\\b(?:FROM|JOIN|INTO|UPDATE|TABLE|TRUNCATE)" + SqlPatterns.SQL_SEP + "([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)?)",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to extract column names from SELECT
     private static final Pattern SELECT_COLUMNS_PATTERN = Pattern.compile(
-        "\\bSELECT\\s+(.+?)\\s+FROM\\b",
+        "\\bSELECT" + SqlPatterns.SQL_SEP + "(.+?)" + SqlPatterns.SQL_SEP + "FROM\\b",
         Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to extract columns from INSERT
     private static final Pattern INSERT_COLUMNS_PATTERN = Pattern.compile(
-        "\\bINSERT\\s+INTO\\s+[a-zA-Z_][a-zA-Z0-9_.]*\\s*\\(([^)]+)\\)",
-        Pattern.CASE_INSENSITIVE
+        "\\bINSERT" + SqlPatterns.SQL_SEP + "INTO" + SqlPatterns.SQL_SEP + "[a-zA-Z_][a-zA-Z0-9_.]*" + SqlPatterns.SQL_OPTIONAL_SEP + "\\(([^)]+)\\)",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to extract columns from UPDATE SET
     private static final Pattern UPDATE_COLUMNS_PATTERN = Pattern.compile(
-        "\\bSET\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
-        Pattern.CASE_INSENSITIVE
+        "\\bSET" + SqlPatterns.SQL_SEP + "([a-zA-Z_][a-zA-Z0-9_]*)",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to parse column names (handles table.column and aliases)

--- a/src/main/java/org/pjdbc/sql/SchemaTransformer.java
+++ b/src/main/java/org/pjdbc/sql/SchemaTransformer.java
@@ -4,6 +4,8 @@ import java.sql.SQLException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.pjdbc.sql.SqlPatterns;
+
 /**
  * Transformer that adds a schema prefix to table names in SQL.
  *
@@ -42,10 +44,10 @@ public class SchemaTransformer extends AbstractJdbcTransformer {
     // - INTO tablename
     // - UPDATE tablename
     // - TABLE tablename (for TRUNCATE TABLE, etc.)
-    // Captures: keyword, optional whitespace, table name (not already qualified)
+    // Captures: keyword, original separator, table name (not already qualified)
     private static final Pattern TABLE_PATTERN = Pattern.compile(
-        "\\b(FROM|JOIN|INTO|UPDATE|TABLE)\\s+(?!\\w+\\.)([a-zA-Z_][a-zA-Z0-9_]*)",
-        Pattern.CASE_INSENSITIVE
+        "\\b(FROM|JOIN|INTO|UPDATE|TABLE)(" + SqlPatterns.SQL_SEP + ")(?!\\w+\\.)([a-zA-Z_][a-zA-Z0-9_]*)",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     /**
@@ -71,9 +73,10 @@ public class SchemaTransformer extends AbstractJdbcTransformer {
 
         while (matcher.find()) {
             String keyword = matcher.group(1);
-            String tableName = matcher.group(2);
-            // Replace with: keyword + space + schema.tablename
-            matcher.appendReplacement(result, keyword + " " + schemaPrefix + tableName);
+            String separator = matcher.group(2);
+            String tableName = matcher.group(3);
+            // Replace with: keyword + original separator + schema.tablename
+            matcher.appendReplacement(result, Matcher.quoteReplacement(keyword + separator + schemaPrefix + tableName));
         }
         matcher.appendTail(result);
 

--- a/src/main/java/org/pjdbc/sql/SqlPatterns.java
+++ b/src/main/java/org/pjdbc/sql/SqlPatterns.java
@@ -1,0 +1,32 @@
+package org.pjdbc.sql;
+
+/**
+ * Common SQL regular expression patterns for secure SQL parsing and transformation.
+ *
+ * <p>These patterns are designed to be used in security-sensitive drivers like
+ * ReadonlyDriver and SchemaValidationDriver to prevent bypasses using SQL comments.</p>
+ */
+public class SqlPatterns {
+    /**
+     * Pattern for a SQL separator, which can be one or more whitespace characters,
+     * block comments, or line comments.
+     *
+     * <p>Note: When using this pattern to match block comments spanning multiple lines,
+     * the Pattern.DOTALL flag must be used.</p>
+     */
+    public static final String SQL_SEP = "(?:\\s+|/\\*.*?\\*/|--[^\\r\\n]*)+";
+
+    /**
+     * Pattern for the beginning of a SQL statement, matching zero or more
+     * leading separators (whitespace or comments).
+     *
+     * <p>Note: When using this pattern, the Pattern.DOTALL flag must be used
+     * to correctly handle multi-line block comments.</p>
+     */
+    public static final String SQL_PREFIX = "^(?:\\s+|/\\*.*?\\*/|--[^\\r\\n]*)*";
+
+    /**
+     * Pattern for an optional SQL separator (zero or more).
+     */
+    public static final String SQL_OPTIONAL_SEP = "(?:\\s+|/\\*.*?\\*/|--[^\\r\\n]*)*";
+}

--- a/src/test/java/org/pjdbc/conformance/ParameterDefaultConformanceTest.java
+++ b/src/test/java/org/pjdbc/conformance/ParameterDefaultConformanceTest.java
@@ -122,7 +122,7 @@ public class ParameterDefaultConformanceTest extends DriverConformanceTest {
     }
 
     @Test
-    @DisplayName("Parameter names are valid identifiers")
+    @DisplayName("Parameter names are valid identifiers or wildcards")
     void parameterNamesAreValidIdentifiers() {
         for (DriverCapability driver : capabilities.getAllDrivers()) {
             if (driver.parameters() == null) continue;
@@ -130,9 +130,10 @@ public class ParameterDefaultConformanceTest extends DriverConformanceTest {
             for (DriverCapability.Parameter param : driver.parameters()) {
                 assertNotNull(param.name(), "Parameter name should not be null in " + driver.name());
                 assertFalse(param.name().isEmpty(), "Parameter name should not be empty in " + driver.name());
-                assertTrue(param.name().matches("[a-zA-Z][a-zA-Z0-9_]*"),
+                // Support both standard identifiers and wildcard patterns like rename.*
+                assertTrue(param.name().matches("[a-zA-Z][a-zA-Z0-9_]*(\\.\\*)?"),
                     "Parameter name '" + param.name() + "' in " + driver.name() +
-                    " should be a valid identifier");
+                    " should be a valid identifier or wildcard pattern");
             }
         }
     }

--- a/src/test/java/org/pjdbc/drivers/ReadonlyDriverSecurityTest.java
+++ b/src/test/java/org/pjdbc/drivers/ReadonlyDriverSecurityTest.java
@@ -1,0 +1,56 @@
+package org.pjdbc.drivers;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ReadonlyDriverSecurityTest {
+
+    @BeforeClass
+    public static void loadDriver() throws ClassNotFoundException {
+        Class.forName("org.pjdbc.drivers.ReadonlyDriver");
+    }
+
+    @Test
+    public void testCommentBypass() throws SQLException {
+        String url = "jdbc:readonly:jdbc:h2:mem:test_comment_bypass";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                // This SHOULD be blocked, but if it bypasses, it will try to execute it on H2.
+                // H2 might fail because the table doesn't exist, but we want to see if ReadonlyDriver blocks it.
+                try {
+                    stmt.executeUpdate("/* comment */ INSERT INTO test_table VALUES (1)");
+                    fail("Expected SQLException for INSERT with leading comment");
+                } catch (SQLException e) {
+                    if (!e.getMessage().contains("ReadonlyDriver")) {
+                        fail("Expected ReadonlyDriver to block the statement, but it might have been passed to H2: " + e.getMessage());
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testLineCommentBypass() throws SQLException {
+        String url = "jdbc:readonly:jdbc:h2:mem:test_line_comment_bypass";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                try {
+                    stmt.executeUpdate("-- line comment\nINSERT INTO test_table VALUES (1)");
+                    fail("Expected SQLException for INSERT with leading line comment");
+                } catch (SQLException e) {
+                    if (!e.getMessage().contains("ReadonlyDriver")) {
+                        fail("Expected ReadonlyDriver to block the statement: " + e.getMessage());
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/org/pjdbc/drivers/SchemaValidationDriverSecurityTest.java
+++ b/src/test/java/org/pjdbc/drivers/SchemaValidationDriverSecurityTest.java
@@ -1,0 +1,76 @@
+package org.pjdbc.drivers;
+
+import static org.junit.Assert.fail;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class SchemaValidationDriverSecurityTest {
+
+    @BeforeClass
+    public static void loadDriver() throws ClassNotFoundException {
+        Class.forName("org.pjdbc.drivers.SchemaValidationDriver");
+    }
+
+    @Test
+    public void testCommentBypass() throws SQLException {
+        // Block "secret_table"
+        String url = "jdbc:schema[blockedTables=secret_table,mode=blacklist]:jdbc:h2:mem:test_schema_bypass";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                // This SHOULD be blocked
+                try {
+                    stmt.executeUpdate("/* comment */ INSERT INTO secret_table VALUES (1)");
+                    fail("Expected SQLException for blocked table with leading comment");
+                } catch (SQLException e) {
+                    if (!e.getMessage().contains("SchemaValidationDriver")) {
+                        fail("Expected SchemaValidationDriver to block the statement: " + e.getMessage());
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testSeparatorCommentBypass() throws SQLException {
+        // Block "secret_table"
+        String url = "jdbc:schema[blockedTables=secret_table,mode=blacklist]:jdbc:h2:mem:test_schema_sep_bypass";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                // This SHOULD be blocked. Note the comment between INTO and table name.
+                try {
+                    stmt.executeUpdate("INSERT INTO/**/secret_table VALUES (1)");
+                    fail("Expected SQLException for blocked table with comment separator");
+                } catch (SQLException e) {
+                    if (!e.getMessage().contains("SchemaValidationDriver")) {
+                        fail("Expected SchemaValidationDriver to block the statement: " + e.getMessage());
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testColumnCommentBypass() throws SQLException {
+        // Block "secret_column"
+        String url = "jdbc:schema[blockedColumns=secret_column,mode=blacklist]:jdbc:h2:mem:test_schema_col_bypass";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                // This SHOULD be blocked
+                try {
+                    stmt.executeQuery("SELECT/**/secret_column/**/FROM/**/some_table");
+                    fail("Expected SQLException for blocked column with comment separator");
+                } catch (SQLException e) {
+                    if (!e.getMessage().contains("SchemaValidationDriver")) {
+                        fail("Expected SchemaValidationDriver to block the statement: " + e.getMessage());
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/org/pjdbc/sql/SchemaTransformerSecurityTest.java
+++ b/src/test/java/org/pjdbc/sql/SchemaTransformerSecurityTest.java
@@ -1,0 +1,36 @@
+package org.pjdbc.sql;
+
+import static org.junit.Assert.assertEquals;
+
+import java.sql.SQLException;
+
+import org.junit.Test;
+
+public class SchemaTransformerSecurityTest {
+
+    @Test
+    public void testCommentAwareTransformation() throws SQLException {
+        SchemaTransformer transformer = new SchemaTransformer("tenant123");
+
+        // Basic transformation
+        assertEquals("SELECT * FROM tenant123.users", transformer.transformSql("SELECT * FROM users"));
+
+        // Transformation with comments
+        assertEquals("SELECT * FROM/**/tenant123.users", transformer.transformSql("SELECT * FROM/**/users"));
+        assertEquals("SELECT * FROM  /* comment */  tenant123.users", transformer.transformSql("SELECT * FROM  /* comment */  users"));
+        assertEquals("SELECT * FROM -- comment\ntenant123.users", transformer.transformSql("SELECT * FROM -- comment\nusers"));
+
+        // Multiple joins with comments
+        String sql = "SELECT * FROM users JOIN/**/orders ON users.id = orders.user_id";
+        String expected = "SELECT * FROM tenant123.users JOIN/**/tenant123.orders ON users.id = orders.user_id";
+        assertEquals(expected, transformer.transformSql(sql));
+    }
+
+    @Test
+    public void testMultiLineComment() throws SQLException {
+        SchemaTransformer transformer = new SchemaTransformer("tenant123");
+        String sql = "SELECT * FROM /* multi\nline\ncomment */ users";
+        String expected = "SELECT * FROM /* multi\nline\ncomment */ tenant123.users";
+        assertEquals(expected, transformer.transformSql(sql));
+    }
+}


### PR DESCRIPTION
### 🛡️ Sentinel: [HIGH] Fix SQL comment bypass in security drivers

🚨 **Severity:** HIGH

💡 **Vulnerability:** 
Security-sensitive drivers such as `ReadonlyDriver` and `SchemaValidationDriver` relied on simple regex patterns (using `\s+` or `^\s*`) to detect SQL keywords. These patterns could be bypassed by using SQL comments as separators instead of whitespace. For example:
- `/* comment */ INSERT` would bypass `ReadonlyDriver`'s DML detection.
- `INSERT/**/INTO secret_table` would bypass `SchemaValidationDriver`'s table blocking.

🎯 **Impact:** 
Attackers could execute unauthorized write operations on read-only connections or access blocked tables/columns by cloaking keywords with comments.

🔧 **Fix:** 
- Created a centralized `SqlPatterns` utility class in `org.pjdbc.sql` that defines `SQL_SEP`, `SQL_PREFIX`, and `SQL_OPTIONAL_SEP` patterns. These patterns correctly account for whitespace, block comments (`/* ... */`), and line comments (`-- ...`).
- Updated `ReadonlyDriver`, `SchemaValidationDriver`, and `SchemaTransformer` to use these robust patterns.
- Ensured `Pattern.DOTALL` is used where necessary to handle multi-line comments.
- Fixed a minor regression in `ParameterDefaultConformanceTest` to support valid parameter wildcards like `rename.*`.

✅ **Verification:** 
- Added `ReadonlyDriverSecurityTest`, `SchemaValidationDriverSecurityTest`, and `SchemaTransformerSecurityTest` with various comment-based bypass attempts.
- Ran all existing tests using `mvn test -Pfast` to ensure no regressions. All 941 tests passed.

---
*PR created automatically by Jules for task [3733279405908359281](https://jules.google.com/task/3733279405908359281) started by @davidaventimiglia-professional*