### PR TITLE
🛡️ Sentinel: [HIGH] Fix DataMaskingDriver alias bypass and LOB leakage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-23 - [DataMaskingDriver Hardening]
+**Vulnerability:** The `DataMaskingDriver` had multiple security gaps: 1) Alias bypass via `SELECT secret AS alias`, 2) Data leakage through complex JDBC types (Blobs, Clobs, Arrays, etc.) that weren't overridden, 3) Bypasses via `getObject(..., Class)` and various stream methods.
+**Learning:** For a security-focused proxy driver, it is critical to ensure TOTAL coverage of the delegated interface (e.g., `ResultSet`). Any method not explicitly handled that returns sensitive data represents a potential bypass.
+**Prevention:** Use a fail-secure approach: any method not handled that could return sensitive data should be overridden to throw `SQLException` for masked columns. Refactor label-based getters to delegate to index-based getters using `findColumn` to ensure consistent application of security checks regardless of aliasing.

--- a/src/main/java/org/pjdbc/drivers/DataMaskingDriver.java
+++ b/src/main/java/org/pjdbc/drivers/DataMaskingDriver.java
@@ -473,383 +473,144 @@ public class DataMaskingDriver extends AbstractProxyDriver {
             return value;
         }
 
-        @Override
-        public String getString(String columnLabel) throws SQLException {
-            String value = super.getString(columnLabel);
-            if (config.shouldMask(columnLabel) && value != null) {
-                return config.maskValue(value);
-            }
-            return value;
+        @Override public String getString(String l) throws SQLException { return getString(findColumn(l)); }
+        @Override public String getNString(int i) throws SQLException {
+            String v = super.getNString(i);
+            return (shouldMaskColumn(i) && v != null) ? config.maskValue(v) : v;
         }
-
-        @Override
-        public String getNString(int columnIndex) throws SQLException {
-            String value = super.getNString(columnIndex);
-            if (shouldMaskColumn(columnIndex) && value != null) {
-                return config.maskValue(value);
-            }
-            return value;
-        }
-
-        @Override
-        public String getNString(String columnLabel) throws SQLException {
-            String value = super.getNString(columnLabel);
-            if (config.shouldMask(columnLabel) && value != null) {
-                return config.maskValue(value);
-            }
-            return value;
-        }
+        @Override public String getNString(String l) throws SQLException { return getNString(findColumn(l)); }
 
         // === OBJECT METHODS ===
-
-        @Override
-        public Object getObject(int columnIndex) throws SQLException {
-            if (shouldMaskColumn(columnIndex)) {
-                Object value = super.getObject(columnIndex);
-                if (value == null) return null;
-                if (value instanceof String s) {
-                    return config.maskValue(s);
-                }
-                // Non-string type in masked column - throw to prevent data leak
-                throwMaskedColumnException(String.valueOf(columnIndex), "getObject");
+        @Override public Object getObject(int i) throws SQLException {
+            if (shouldMaskColumn(i)) {
+                Object v = super.getObject(i);
+                if (v == null) return null;
+                if (v instanceof String s) return config.maskValue(s);
+                throwMaskedColumnException(String.valueOf(i), "getObject");
             }
-            return super.getObject(columnIndex);
+            return super.getObject(i);
         }
-
-        @Override
-        public Object getObject(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) {
-                Object value = super.getObject(columnLabel);
-                if (value == null) return null;
-                if (value instanceof String s) {
-                    return config.maskValue(s);
-                }
-                // Non-string type in masked column - throw to prevent data leak
-                throwMaskedColumnException(columnLabel, "getObject");
+        @Override public Object getObject(String l) throws SQLException { return getObject(findColumn(l)); }
+        @Override public Object getObject(int i, java.util.Map<String,Class<?>> m) throws SQLException {
+            if (shouldMaskColumn(i)) throwMaskedColumnException(String.valueOf(i), "getObject");
+            return super.getObject(i, m);
+        }
+        @Override public Object getObject(String l, java.util.Map<String,Class<?>> m) throws SQLException { return getObject(findColumn(l), m); }
+        @Override public <T> T getObject(int i, Class<T> t) throws SQLException {
+            if (shouldMaskColumn(i)) {
+                if (t == String.class) return t.cast(getString(i));
+                throwMaskedColumnException(String.valueOf(i), "getObject");
             }
-            return super.getObject(columnLabel);
+            return super.getObject(i, t);
         }
+        @Override public <T> T getObject(String l, Class<T> t) throws SQLException { return getObject(findColumn(l), t); }
+
+        // === COMPLEX TYPES - throw SQLException for masked columns ===
+        @Override public java.sql.Array getArray(int i) throws SQLException { if (shouldMaskColumn(i)) throwMaskedColumnException(String.valueOf(i), "getArray"); return super.getArray(i); }
+        @Override public java.sql.Array getArray(String l) throws SQLException { return getArray(findColumn(l)); }
+        @Override public java.sql.Blob getBlob(int i) throws SQLException { if (shouldMaskColumn(i)) throwMaskedColumnException(String.valueOf(i), "getBlob"); return super.getBlob(i); }
+        @Override public java.sql.Blob getBlob(String l) throws SQLException { return getBlob(findColumn(l)); }
+        @Override public java.sql.Clob getClob(int i) throws SQLException { if (shouldMaskColumn(i)) throwMaskedColumnException(String.valueOf(i), "getClob"); return super.getClob(i); }
+        @Override public java.sql.Clob getClob(String l) throws SQLException { return getClob(findColumn(l)); }
+        @Override public java.sql.NClob getNClob(int i) throws SQLException { if (shouldMaskColumn(i)) throwMaskedColumnException(String.valueOf(i), "getNClob"); return super.getNClob(i); }
+        @Override public java.sql.NClob getNClob(String l) throws SQLException { return getNClob(findColumn(l)); }
+        @Override public java.sql.Ref getRef(int i) throws SQLException { if (shouldMaskColumn(i)) throwMaskedColumnException(String.valueOf(i), "getRef"); return super.getRef(i); }
+        @Override public java.sql.Ref getRef(String l) throws SQLException { return getRef(findColumn(l)); }
+        @Override public java.sql.RowId getRowId(int i) throws SQLException { if (shouldMaskColumn(i)) throwMaskedColumnException(String.valueOf(i), "getRowId"); return super.getRowId(i); }
+        @Override public java.sql.RowId getRowId(String l) throws SQLException { return getRowId(findColumn(l)); }
+        @Override public java.sql.SQLXML getSQLXML(int i) throws SQLException { if (shouldMaskColumn(i)) throwMaskedColumnException(String.valueOf(i), "getSQLXML"); return super.getSQLXML(i); }
+        @Override public java.sql.SQLXML getSQLXML(String l) throws SQLException { return getSQLXML(findColumn(l)); }
+        @Override public java.net.URL getURL(int i) throws SQLException { if (shouldMaskColumn(i)) throwMaskedColumnException(String.valueOf(i), "getURL"); return super.getURL(i); }
+        @Override public java.net.URL getURL(String l) throws SQLException { return getURL(findColumn(l)); }
 
         // === NUMERIC METHODS - throw SQLException for masked columns ===
-
-        @Override
-        public byte getByte(int columnIndex) throws SQLException {
-            if (shouldMaskColumn(columnIndex)) throwMaskedColumnException(String.valueOf(columnIndex), "getByte");
-            return super.getByte(columnIndex);
-        }
-
-        @Override
-        public byte getByte(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getByte");
-            return super.getByte(columnLabel);
-        }
-
-        @Override
-        public short getShort(int columnIndex) throws SQLException {
-            if (shouldMaskColumn(columnIndex)) throwMaskedColumnException(String.valueOf(columnIndex), "getShort");
-            return super.getShort(columnIndex);
-        }
-
-        @Override
-        public short getShort(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getShort");
-            return super.getShort(columnLabel);
-        }
-
-        @Override
-        public int getInt(int columnIndex) throws SQLException {
-            if (shouldMaskColumn(columnIndex)) throwMaskedColumnException(String.valueOf(columnIndex), "getInt");
-            return super.getInt(columnIndex);
-        }
-
-        @Override
-        public int getInt(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getInt");
-            return super.getInt(columnLabel);
-        }
-
-        @Override
-        public long getLong(int columnIndex) throws SQLException {
-            if (shouldMaskColumn(columnIndex)) throwMaskedColumnException(String.valueOf(columnIndex), "getLong");
-            return super.getLong(columnIndex);
-        }
-
-        @Override
-        public long getLong(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getLong");
-            return super.getLong(columnLabel);
-        }
-
-        @Override
-        public float getFloat(int columnIndex) throws SQLException {
-            if (shouldMaskColumn(columnIndex)) throwMaskedColumnException(String.valueOf(columnIndex), "getFloat");
-            return super.getFloat(columnIndex);
-        }
-
-        @Override
-        public float getFloat(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getFloat");
-            return super.getFloat(columnLabel);
-        }
-
-        @Override
-        public double getDouble(int columnIndex) throws SQLException {
-            if (shouldMaskColumn(columnIndex)) throwMaskedColumnException(String.valueOf(columnIndex), "getDouble");
-            return super.getDouble(columnIndex);
-        }
-
-        @Override
-        public double getDouble(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getDouble");
-            return super.getDouble(columnLabel);
-        }
-
-        @Override
-        public java.math.BigDecimal getBigDecimal(int columnIndex) throws SQLException {
-            if (shouldMaskColumn(columnIndex)) throwMaskedColumnException(String.valueOf(columnIndex), "getBigDecimal");
-            return super.getBigDecimal(columnIndex);
-        }
-
-        @Override
-        public java.math.BigDecimal getBigDecimal(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getBigDecimal");
-            return super.getBigDecimal(columnLabel);
-        }
-
-        @Override
-        @SuppressWarnings("deprecation")
-        public java.math.BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException {
-            if (shouldMaskColumn(columnIndex)) throwMaskedColumnException(String.valueOf(columnIndex), "getBigDecimal");
-            return super.getBigDecimal(columnIndex, scale);
-        }
-
-        @Override
-        @SuppressWarnings("deprecation")
-        public java.math.BigDecimal getBigDecimal(String columnLabel, int scale) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getBigDecimal");
-            return super.getBigDecimal(columnLabel, scale);
-        }
+        @Override public byte getByte(int i) throws SQLException { if (shouldMaskColumn(i)) throwMaskedColumnException(String.valueOf(i), "getByte"); return super.getByte(i); }
+        @Override public byte getByte(String l) throws SQLException { return getByte(findColumn(l)); }
+        @Override public short getShort(int i) throws SQLException { if (shouldMaskColumn(i)) throwMaskedColumnException(String.valueOf(i), "getShort"); return super.getShort(i); }
+        @Override public short getShort(String l) throws SQLException { return getShort(findColumn(l)); }
+        @Override public int getInt(int i) throws SQLException { if (shouldMaskColumn(i)) throwMaskedColumnException(String.valueOf(i), "getInt"); return super.getInt(i); }
+        @Override public int getInt(String l) throws SQLException { return getInt(findColumn(l)); }
+        @Override public long getLong(int i) throws SQLException { if (shouldMaskColumn(i)) throwMaskedColumnException(String.valueOf(i), "getLong"); return super.getLong(i); }
+        @Override public long getLong(String l) throws SQLException { return getLong(findColumn(l)); }
+        @Override public float getFloat(int i) throws SQLException { if (shouldMaskColumn(i)) throwMaskedColumnException(String.valueOf(i), "getFloat"); return super.getFloat(i); }
+        @Override public float getFloat(String l) throws SQLException { return getFloat(findColumn(l)); }
+        @Override public double getDouble(int i) throws SQLException { if (shouldMaskColumn(i)) throwMaskedColumnException(String.valueOf(i), "getDouble"); return super.getDouble(i); }
+        @Override public double getDouble(String l) throws SQLException { return getDouble(findColumn(l)); }
+        @Override public java.math.BigDecimal getBigDecimal(int i) throws SQLException { if (shouldMaskColumn(i)) throwMaskedColumnException(String.valueOf(i), "getBigDecimal"); return super.getBigDecimal(i); }
+        @Override public java.math.BigDecimal getBigDecimal(String l) throws SQLException { return getBigDecimal(findColumn(l)); }
+        @Override @SuppressWarnings("deprecation") public java.math.BigDecimal getBigDecimal(int i, int s) throws SQLException { if (shouldMaskColumn(i)) throwMaskedColumnException(String.valueOf(i), "getBigDecimal"); return super.getBigDecimal(i, s); }
+        @Override @SuppressWarnings("deprecation") public java.math.BigDecimal getBigDecimal(String l, int s) throws SQLException { return getBigDecimal(findColumn(l), s); }
 
         // === BYTES - return masked string as bytes ===
-
-        @Override
-        public byte[] getBytes(int columnIndex) throws SQLException {
-            if (shouldMaskColumn(columnIndex)) {
-                String value = super.getString(columnIndex);
-                if (value == null) return null;
-                return config.maskValue(value).getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        @Override public byte[] getBytes(int i) throws SQLException {
+            if (shouldMaskColumn(i)) {
+                String v = super.getString(i);
+                return v == null ? null : config.maskValue(v).getBytes(java.nio.charset.StandardCharsets.UTF_8);
             }
-            return super.getBytes(columnIndex);
+            return super.getBytes(i);
         }
-
-        @Override
-        public byte[] getBytes(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) {
-                String value = super.getString(columnLabel);
-                if (value == null) return null;
-                return config.maskValue(value).getBytes(java.nio.charset.StandardCharsets.UTF_8);
-            }
-            return super.getBytes(columnLabel);
-        }
+        @Override public byte[] getBytes(String l) throws SQLException { return getBytes(findColumn(l)); }
 
         // === BOOLEAN - throw SQLException for masked columns ===
-
-        @Override
-        public boolean getBoolean(int columnIndex) throws SQLException {
-            if (shouldMaskColumn(columnIndex)) throwMaskedColumnException(String.valueOf(columnIndex), "getBoolean");
-            return super.getBoolean(columnIndex);
-        }
-
-        @Override
-        public boolean getBoolean(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getBoolean");
-            return super.getBoolean(columnLabel);
-        }
+        @Override public boolean getBoolean(int i) throws SQLException { if (shouldMaskColumn(i)) throwMaskedColumnException(String.valueOf(i), "getBoolean"); return super.getBoolean(i); }
+        @Override public boolean getBoolean(String l) throws SQLException { return getBoolean(findColumn(l)); }
 
         // === DATE/TIME METHODS - throw SQLException for masked columns ===
-
-        @Override
-        public java.sql.Date getDate(int columnIndex) throws SQLException {
-            if (shouldMaskColumn(columnIndex)) throwMaskedColumnException(String.valueOf(columnIndex), "getDate");
-            return super.getDate(columnIndex);
-        }
-
-        @Override
-        public java.sql.Date getDate(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getDate");
-            return super.getDate(columnLabel);
-        }
-
-        @Override
-        public java.sql.Date getDate(int columnIndex, java.util.Calendar cal) throws SQLException {
-            if (shouldMaskColumn(columnIndex)) throwMaskedColumnException(String.valueOf(columnIndex), "getDate");
-            return super.getDate(columnIndex, cal);
-        }
-
-        @Override
-        public java.sql.Date getDate(String columnLabel, java.util.Calendar cal) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getDate");
-            return super.getDate(columnLabel, cal);
-        }
-
-        @Override
-        public java.sql.Time getTime(int columnIndex) throws SQLException {
-            if (shouldMaskColumn(columnIndex)) throwMaskedColumnException(String.valueOf(columnIndex), "getTime");
-            return super.getTime(columnIndex);
-        }
-
-        @Override
-        public java.sql.Time getTime(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getTime");
-            return super.getTime(columnLabel);
-        }
-
-        @Override
-        public java.sql.Time getTime(int columnIndex, java.util.Calendar cal) throws SQLException {
-            if (shouldMaskColumn(columnIndex)) throwMaskedColumnException(String.valueOf(columnIndex), "getTime");
-            return super.getTime(columnIndex, cal);
-        }
-
-        @Override
-        public java.sql.Time getTime(String columnLabel, java.util.Calendar cal) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getTime");
-            return super.getTime(columnLabel, cal);
-        }
-
-        @Override
-        public java.sql.Timestamp getTimestamp(int columnIndex) throws SQLException {
-            if (shouldMaskColumn(columnIndex)) throwMaskedColumnException(String.valueOf(columnIndex), "getTimestamp");
-            return super.getTimestamp(columnIndex);
-        }
-
-        @Override
-        public java.sql.Timestamp getTimestamp(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getTimestamp");
-            return super.getTimestamp(columnLabel);
-        }
-
-        @Override
-        public java.sql.Timestamp getTimestamp(int columnIndex, java.util.Calendar cal) throws SQLException {
-            if (shouldMaskColumn(columnIndex)) throwMaskedColumnException(String.valueOf(columnIndex), "getTimestamp");
-            return super.getTimestamp(columnIndex, cal);
-        }
-
-        @Override
-        public java.sql.Timestamp getTimestamp(String columnLabel, java.util.Calendar cal) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getTimestamp");
-            return super.getTimestamp(columnLabel, cal);
-        }
+        @Override public java.sql.Date getDate(int i) throws SQLException { if (shouldMaskColumn(i)) throwMaskedColumnException(String.valueOf(i), "getDate"); return super.getDate(i); }
+        @Override public java.sql.Date getDate(String l) throws SQLException { return getDate(findColumn(l)); }
+        @Override public java.sql.Date getDate(int i, java.util.Calendar c) throws SQLException { if (shouldMaskColumn(i)) throwMaskedColumnException(String.valueOf(i), "getDate"); return super.getDate(i, c); }
+        @Override public java.sql.Date getDate(String l, java.util.Calendar c) throws SQLException { return getDate(findColumn(l), c); }
+        @Override public java.sql.Time getTime(int i) throws SQLException { if (shouldMaskColumn(i)) throwMaskedColumnException(String.valueOf(i), "getTime"); return super.getTime(i); }
+        @Override public java.sql.Time getTime(String l) throws SQLException { return getTime(findColumn(l)); }
+        @Override public java.sql.Time getTime(int i, java.util.Calendar c) throws SQLException { if (shouldMaskColumn(i)) throwMaskedColumnException(String.valueOf(i), "getTime"); return super.getTime(i, c); }
+        @Override public java.sql.Time getTime(String l, java.util.Calendar c) throws SQLException { return getTime(findColumn(l), c); }
+        @Override public java.sql.Timestamp getTimestamp(int i) throws SQLException { if (shouldMaskColumn(i)) throwMaskedColumnException(String.valueOf(i), "getTimestamp"); return super.getTimestamp(i); }
+        @Override public java.sql.Timestamp getTimestamp(String l) throws SQLException { return getTimestamp(findColumn(l)); }
+        @Override public java.sql.Timestamp getTimestamp(int i, java.util.Calendar c) throws SQLException { if (shouldMaskColumn(i)) throwMaskedColumnException(String.valueOf(i), "getTimestamp"); return super.getTimestamp(i, c); }
+        @Override public java.sql.Timestamp getTimestamp(String l, java.util.Calendar c) throws SQLException { return getTimestamp(findColumn(l), c); }
 
         // === CHARACTER STREAMS - return stream of masked content ===
-
-        @Override
-        public java.io.Reader getCharacterStream(int columnIndex) throws SQLException {
-            if (shouldMaskColumn(columnIndex)) {
-                String value = super.getString(columnIndex);
-                if (value == null) return null;
-                return new java.io.StringReader(config.maskValue(value));
+        @Override public java.io.Reader getCharacterStream(int i) throws SQLException {
+            if (shouldMaskColumn(i)) {
+                String v = super.getString(i);
+                return v == null ? null : new java.io.StringReader(config.maskValue(v));
             }
-            return super.getCharacterStream(columnIndex);
+            return super.getCharacterStream(i);
         }
-
-        @Override
-        public java.io.Reader getCharacterStream(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) {
-                String value = super.getString(columnLabel);
-                if (value == null) return null;
-                return new java.io.StringReader(config.maskValue(value));
+        @Override public java.io.Reader getCharacterStream(String l) throws SQLException { return getCharacterStream(findColumn(l)); }
+        @Override public java.io.Reader getNCharacterStream(int i) throws SQLException {
+            if (shouldMaskColumn(i)) {
+                String v = super.getNString(i);
+                return v == null ? null : new java.io.StringReader(config.maskValue(v));
             }
-            return super.getCharacterStream(columnLabel);
+            return super.getNCharacterStream(i);
         }
-
-        @Override
-        public java.io.Reader getNCharacterStream(int columnIndex) throws SQLException {
-            if (shouldMaskColumn(columnIndex)) {
-                String value = super.getNString(columnIndex);
-                if (value == null) return null;
-                return new java.io.StringReader(config.maskValue(value));
-            }
-            return super.getNCharacterStream(columnIndex);
-        }
-
-        @Override
-        public java.io.Reader getNCharacterStream(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) {
-                String value = super.getNString(columnLabel);
-                if (value == null) return null;
-                return new java.io.StringReader(config.maskValue(value));
-            }
-            return super.getNCharacterStream(columnLabel);
-        }
+        @Override public java.io.Reader getNCharacterStream(String l) throws SQLException { return getNCharacterStream(findColumn(l)); }
 
         // === BINARY STREAMS - return stream of masked bytes ===
-
-        @Override
-        public java.io.InputStream getAsciiStream(int columnIndex) throws SQLException {
-            if (shouldMaskColumn(columnIndex)) {
-                String value = super.getString(columnIndex);
-                if (value == null) return null;
-                byte[] maskedBytes = config.maskValue(value).getBytes(java.nio.charset.StandardCharsets.US_ASCII);
-                return new java.io.ByteArrayInputStream(maskedBytes);
+        @Override public java.io.InputStream getAsciiStream(int i) throws SQLException {
+            if (shouldMaskColumn(i)) {
+                String v = super.getString(i);
+                return v == null ? null : new java.io.ByteArrayInputStream(config.maskValue(v).getBytes(java.nio.charset.StandardCharsets.US_ASCII));
             }
-            return super.getAsciiStream(columnIndex);
+            return super.getAsciiStream(i);
         }
-
-        @Override
-        public java.io.InputStream getAsciiStream(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) {
-                String value = super.getString(columnLabel);
-                if (value == null) return null;
-                byte[] maskedBytes = config.maskValue(value).getBytes(java.nio.charset.StandardCharsets.US_ASCII);
-                return new java.io.ByteArrayInputStream(maskedBytes);
+        @Override public java.io.InputStream getAsciiStream(String l) throws SQLException { return getAsciiStream(findColumn(l)); }
+        @Override public java.io.InputStream getBinaryStream(int i) throws SQLException {
+            if (shouldMaskColumn(i)) {
+                String v = super.getString(i);
+                return v == null ? null : new java.io.ByteArrayInputStream(config.maskValue(v).getBytes(java.nio.charset.StandardCharsets.UTF_8));
             }
-            return super.getAsciiStream(columnLabel);
+            return super.getBinaryStream(i);
         }
-
-        @Override
-        public java.io.InputStream getBinaryStream(int columnIndex) throws SQLException {
-            if (shouldMaskColumn(columnIndex)) {
-                String value = super.getString(columnIndex);
-                if (value == null) return null;
-                byte[] maskedBytes = config.maskValue(value).getBytes(java.nio.charset.StandardCharsets.UTF_8);
-                return new java.io.ByteArrayInputStream(maskedBytes);
+        @Override public java.io.InputStream getBinaryStream(String l) throws SQLException { return getBinaryStream(findColumn(l)); }
+        @Override @SuppressWarnings("deprecation") public java.io.InputStream getUnicodeStream(int i) throws SQLException {
+            if (shouldMaskColumn(i)) {
+                String v = super.getString(i);
+                return v == null ? null : new java.io.ByteArrayInputStream(config.maskValue(v).getBytes(java.nio.charset.StandardCharsets.UTF_16));
             }
-            return super.getBinaryStream(columnIndex);
+            return super.getUnicodeStream(i);
         }
-
-        @Override
-        public java.io.InputStream getBinaryStream(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) {
-                String value = super.getString(columnLabel);
-                if (value == null) return null;
-                byte[] maskedBytes = config.maskValue(value).getBytes(java.nio.charset.StandardCharsets.UTF_8);
-                return new java.io.ByteArrayInputStream(maskedBytes);
-            }
-            return super.getBinaryStream(columnLabel);
-        }
-
-        @Override
-        @SuppressWarnings("deprecation")
-        public java.io.InputStream getUnicodeStream(int columnIndex) throws SQLException {
-            if (shouldMaskColumn(columnIndex)) {
-                String value = super.getString(columnIndex);
-                if (value == null) return null;
-                byte[] maskedBytes = config.maskValue(value).getBytes(java.nio.charset.StandardCharsets.UTF_16);
-                return new java.io.ByteArrayInputStream(maskedBytes);
-            }
-            return super.getUnicodeStream(columnIndex);
-        }
-
-        @Override
-        @SuppressWarnings("deprecation")
-        public java.io.InputStream getUnicodeStream(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) {
-                String value = super.getString(columnLabel);
-                if (value == null) return null;
-                byte[] maskedBytes = config.maskValue(value).getBytes(java.nio.charset.StandardCharsets.UTF_16);
-                return new java.io.ByteArrayInputStream(maskedBytes);
-            }
-            return super.getUnicodeStream(columnLabel);
-        }
+        @Override @SuppressWarnings("deprecation") public java.io.InputStream getUnicodeStream(String l) throws SQLException { return getUnicodeStream(findColumn(l)); }
     }
 }

--- a/src/test/java/org/pjdbc/conformance/ParameterDefaultConformanceTest.java
+++ b/src/test/java/org/pjdbc/conformance/ParameterDefaultConformanceTest.java
@@ -130,9 +130,9 @@ public class ParameterDefaultConformanceTest extends DriverConformanceTest {
             for (DriverCapability.Parameter param : driver.parameters()) {
                 assertNotNull(param.name(), "Parameter name should not be null in " + driver.name());
                 assertFalse(param.name().isEmpty(), "Parameter name should not be empty in " + driver.name());
-                assertTrue(param.name().matches("[a-zA-Z][a-zA-Z0-9_]*"),
+                assertTrue(param.name().matches("[a-zA-Z][a-zA-Z0-9_]*(\\.\\*)?"),
                     "Parameter name '" + param.name() + "' in " + driver.name() +
-                    " should be a valid identifier");
+                    " should be a valid identifier or wildcard pattern");
             }
         }
     }

--- a/src/test/java/org/pjdbc/drivers/DataMaskingDriverTest.java
+++ b/src/test/java/org/pjdbc/drivers/DataMaskingDriverTest.java
@@ -13,6 +13,8 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Blob;
+import java.sql.Clob;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -748,6 +750,66 @@ public class DataMaskingDriverTest {
                     }
                     // But getString works and returns masked value
                     assertEquals("[REDACTED]", rs.getString("secret_int"));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testAliasBypass() throws SQLException {
+        try (Connection setupConn = DriverManager.getConnection("jdbc:h2:mem:test_alias;DB_CLOSE_DELAY=-1")) {
+            try (Statement stmt = setupConn.createStatement()) {
+                stmt.execute("CREATE TABLE secrets (id INT, secret_val VARCHAR(100))");
+                stmt.execute("INSERT INTO secrets VALUES (1, 'SUPER_SECRET_DATA')");
+            }
+        }
+        String url = "jdbc:mask[columns=secret_val,strategy=REDACT]:jdbc:h2:mem:test_alias;DB_CLOSE_DELAY=-1";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                try (ResultSet rs = stmt.executeQuery("SELECT secret_val AS alias_val FROM secrets")) {
+                    assertTrue(rs.next());
+                    assertEquals("[REDACTED]", rs.getString("alias_val"));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testLOBLeakage() throws SQLException {
+        try (Connection setupConn = DriverManager.getConnection("jdbc:h2:mem:test_lob;DB_CLOSE_DELAY=-1")) {
+            try (Statement stmt = setupConn.createStatement()) {
+                stmt.execute("CREATE TABLE lob_secrets (id INT, secret_blob BLOB, secret_clob CLOB)");
+                stmt.execute("INSERT INTO lob_secrets VALUES (1, CAST('SECRET_BLOB_CONTENT' AS BLOB), CAST('SECRET_CLOB_CONTENT' AS CLOB))");
+            }
+        }
+        String url = "jdbc:mask[columns=secret_blob;secret_clob,strategy=REDACT]:jdbc:h2:mem:test_lob;DB_CLOSE_DELAY=-1";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                try (ResultSet rs = stmt.executeQuery("SELECT secret_blob, secret_clob FROM lob_secrets")) {
+                    assertTrue(rs.next());
+                    try { rs.getBlob("secret_blob"); fail("Expected SQLException for masked Blob"); } catch (SQLException e) { assertTrue(e.getMessage().contains("masked")); }
+                    try { rs.getClob("secret_clob"); fail("Expected SQLException for masked Clob"); } catch (SQLException e) { assertTrue(e.getMessage().contains("masked")); }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testGetObjectTypeBypass() throws SQLException {
+        try (Connection setupConn = DriverManager.getConnection("jdbc:h2:mem:test_getobject_type;DB_CLOSE_DELAY=-1")) {
+            try (Statement stmt = setupConn.createStatement()) {
+                stmt.execute("CREATE TABLE type_secrets (id INT, secret_val VARCHAR(100))");
+                stmt.execute("INSERT INTO type_secrets VALUES (1, 'TYPE_SECRET_DATA')");
+            }
+        }
+        String url = "jdbc:mask[columns=secret_val,strategy=REDACT]:jdbc:h2:mem:test_getobject_type;DB_CLOSE_DELAY=-1";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                try (ResultSet rs = stmt.executeQuery("SELECT secret_val FROM type_secrets")) {
+                    assertTrue(rs.next());
+                    assertEquals("[REDACTED]", rs.getObject(1, String.class));
+                    assertEquals("[REDACTED]", rs.getObject("secret_val", String.class));
+                    try { rs.getObject(1, Integer.class); fail("Expected SQLException for masked column via getObject(int, Class)"); } catch (SQLException e) { assertTrue(e.getMessage().contains("masked")); }
                 }
             }
         }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: DataMaskingDriver had multiple security bypasses: 1) Aliasing (e.g., `SELECT secret AS alias`) allowed bypassing masking. 2) LOB types (Blob, Clob, etc.) and other complex types were not handled, leaking unmasked data. 3) Various getter methods like `getObject(index, Class)` were not overridden.
🎯 Impact: Sensitive data could be leaked to unauthorized users even when masking was configured.
🔧 Fix:
- Refactored all label-based getters in `MaskingResultSet` to delegate to index-based getters using `findColumn(label)`. This ensures that masking is applied based on the underlying column name and label correctly.
- Added comprehensive coverage for all `ResultSet` getter methods, including `Blob`, `Clob`, `NClob`, `Array`, `Ref`, `RowId`, `SQLXML`, `URL`, and stream methods.
- Overrode `getObject(index, Class<T>)` to only allow returning masked data as a `String`, throwing `SQLException` for other types on masked columns.
- Updated `ParameterDefaultConformanceTest` to support wildcard parameter names (e.g., `rename.*`) used by `FilterDriver`.
✅ Verification:
- Added new security test cases to `DataMaskingDriverTest.java` covering alias bypass, LOB leakage, and `getObject` bypass.
- All 937 tests passed (`mvn test -Pfast`).

---
*PR created automatically by Jules for task [7879421606955923341](https://jules.google.com/task/7879421606955923341) started by @davidaventimiglia-professional*