### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix SQL parsing bypass via comments

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-26 - [Bypass of SQL Parsing via Comments]
+**Vulnerability:** SQL-based security controls (like `SchemaValidationDriver`, `SchemaTransformer`, and `WhereTransformer`) can be bypassed by using SQL comments (`/**/` or `--`) as separators instead of standard whitespace.
+**Learning:** Standard regex patterns using `\\s+` fail to match SQL where keywords are separated by comments, allowing malicious or unauthorized queries to skip validation or transformation layers.
+**Prevention:** Centralize SQL separator regexes to include both whitespace and all supported comment styles, and use these patterns consistently across all security-sensitive SQL parsing logic.

--- a/src/main/java/org/pjdbc/drivers/SchemaValidationDriver.java
+++ b/src/main/java/org/pjdbc/drivers/SchemaValidationDriver.java
@@ -18,6 +18,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.pjdbc.sql.SqlPatterns;
 import org.pjdbc.annotations.DriverCapability;
 import org.pjdbc.annotations.DriverParameter;
 import org.pjdbc.annotations.DriverParameter.ParameterType;
@@ -79,25 +80,25 @@ public class SchemaValidationDriver extends AbstractProxyDriver {
     // Pattern to extract table names from SQL
     // Matches: FROM table, JOIN table, INTO table, UPDATE table, TABLE table (for TRUNCATE)
     private static final Pattern TABLE_PATTERN = Pattern.compile(
-        "\\b(?:FROM|JOIN|INTO|UPDATE|TABLE|TRUNCATE)\\s+([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)?)",
+        "\\b(?:FROM|JOIN|INTO|UPDATE|TABLE|TRUNCATE)" + SqlPatterns.SQL_SEP + "([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)?)",
         Pattern.CASE_INSENSITIVE
     );
 
     // Pattern to extract column names from SELECT
     private static final Pattern SELECT_COLUMNS_PATTERN = Pattern.compile(
-        "\\bSELECT\\s+(.+?)\\s+FROM\\b",
+        "\\bSELECT" + SqlPatterns.SQL_SEP + "(.+?)" + SqlPatterns.SQL_SEP + "FROM\\b",
         Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to extract columns from INSERT
     private static final Pattern INSERT_COLUMNS_PATTERN = Pattern.compile(
-        "\\bINSERT\\s+INTO\\s+[a-zA-Z_][a-zA-Z0-9_.]*\\s*\\(([^)]+)\\)",
+        "\\bINSERT" + SqlPatterns.SQL_SEP + "INTO" + SqlPatterns.SQL_SEP + "[a-zA-Z_][a-zA-Z0-9_.]*" + SqlPatterns.SQL_SEP_OPT + "\\(([^)]+)\\)",
         Pattern.CASE_INSENSITIVE
     );
 
     // Pattern to extract columns from UPDATE SET
     private static final Pattern UPDATE_COLUMNS_PATTERN = Pattern.compile(
-        "\\bSET\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
+        "\\bSET" + SqlPatterns.SQL_SEP + "([a-zA-Z_][a-zA-Z0-9_]*)",
         Pattern.CASE_INSENSITIVE
     );
 

--- a/src/main/java/org/pjdbc/sql/SchemaTransformer.java
+++ b/src/main/java/org/pjdbc/sql/SchemaTransformer.java
@@ -42,9 +42,9 @@ public class SchemaTransformer extends AbstractJdbcTransformer {
     // - INTO tablename
     // - UPDATE tablename
     // - TABLE tablename (for TRUNCATE TABLE, etc.)
-    // Captures: keyword, optional whitespace, table name (not already qualified)
+    // Captures: keyword, separator (whitespace/comments), table name (not already qualified)
     private static final Pattern TABLE_PATTERN = Pattern.compile(
-        "\\b(FROM|JOIN|INTO|UPDATE|TABLE)\\s+(?!\\w+\\.)([a-zA-Z_][a-zA-Z0-9_]*)",
+        "\\b(FROM|JOIN|INTO|UPDATE|TABLE)(" + SqlPatterns.SQL_SEP + ")(?!\\w+\\.)([a-zA-Z_][a-zA-Z0-9_]*)",
         Pattern.CASE_INSENSITIVE
     );
 
@@ -71,9 +71,10 @@ public class SchemaTransformer extends AbstractJdbcTransformer {
 
         while (matcher.find()) {
             String keyword = matcher.group(1);
-            String tableName = matcher.group(2);
-            // Replace with: keyword + space + schema.tablename
-            matcher.appendReplacement(result, keyword + " " + schemaPrefix + tableName);
+            String separator = matcher.group(2);
+            String tableName = matcher.group(3);
+            // Replace with: keyword + separator + schema.tablename (preserving original separator)
+            matcher.appendReplacement(result, Matcher.quoteReplacement(keyword + separator + schemaPrefix + tableName));
         }
         matcher.appendTail(result);
 

--- a/src/main/java/org/pjdbc/sql/SqlPatterns.java
+++ b/src/main/java/org/pjdbc/sql/SqlPatterns.java
@@ -1,0 +1,24 @@
+package org.pjdbc.sql;
+
+/**
+ * Centralized SQL patterns for robust parsing and transformation.
+ */
+public class SqlPatterns {
+
+    /**
+     * Regex for a mandatory SQL separator.
+     * Matches one or more occurrences of whitespace, block comments, or line comments.
+     * Uses non-capturing groups to maintain stable capturing group indices in complex patterns.
+     */
+    public static final String SQL_SEP = "(?:\\s+|/\\*[\\s\\S]*?\\*/|--[^\\r\\n]*)+";
+
+    /**
+     * Regex for an optional SQL separator.
+     * Matches zero or more occurrences of whitespace or comments.
+     */
+    public static final String SQL_SEP_OPT = "(?:\\s+|/\\*[\\s\\S]*?\\*/|--[^\\r\\n]*)*";
+
+    private SqlPatterns() {
+        // Utility class
+    }
+}

--- a/src/main/java/org/pjdbc/sql/WhereTransformer.java
+++ b/src/main/java/org/pjdbc/sql/WhereTransformer.java
@@ -49,13 +49,14 @@ public class WhereTransformer extends AbstractJdbcTransformer {
     // Pattern to find insertion point for new WHERE clause
     // Matches: GROUP BY, HAVING, ORDER BY, LIMIT, OFFSET, UNION, INTERSECT, EXCEPT, or end
     private static final Pattern WHERE_INSERTION_POINT = Pattern.compile(
-        "\\s+(GROUP\\s+BY|HAVING|ORDER\\s+BY|LIMIT|OFFSET|UNION|INTERSECT|EXCEPT|FOR\\s+UPDATE|FOR\\s+SHARE)\\b",
+        SqlPatterns.SQL_SEP + "(GROUP" + SqlPatterns.SQL_SEP + "BY|HAVING|ORDER" + SqlPatterns.SQL_SEP + "BY|LIMIT|OFFSET|UNION|INTERSECT|EXCEPT|FOR" + SqlPatterns.SQL_SEP + "UPDATE|FOR" + SqlPatterns.SQL_SEP + "SHARE)\\b",
         Pattern.CASE_INSENSITIVE
     );
 
     // Pattern to detect SELECT/UPDATE/DELETE statements (not INSERT)
+    // Supports leading comments
     private static final Pattern MODIFIABLE_STATEMENT = Pattern.compile(
-        "^\\s*(SELECT|UPDATE|DELETE)\\b",
+        "^" + SqlPatterns.SQL_SEP_OPT + "(SELECT|UPDATE|DELETE)\\b",
         Pattern.CASE_INSENSITIVE
     );
 
@@ -63,7 +64,7 @@ public class WhereTransformer extends AbstractJdbcTransformer {
     // We need to find WHERE that's not inside parentheses (subquery)
     // This is a simplification - we find WHERE and append at the insertion point
     private static final Pattern WHERE_CLAUSE_END = Pattern.compile(
-        "\\bWHERE\\b(.+?)(?=(GROUP\\s+BY|HAVING|ORDER\\s+BY|LIMIT|OFFSET|UNION|INTERSECT|EXCEPT|FOR\\s+UPDATE|FOR\\s+SHARE|$))",
+        "\\bWHERE\\b(.+?)(?=(GROUP" + SqlPatterns.SQL_SEP + "BY|HAVING|ORDER" + SqlPatterns.SQL_SEP + "BY|LIMIT|OFFSET|UNION|INTERSECT|EXCEPT|FOR" + SqlPatterns.SQL_SEP + "UPDATE|FOR" + SqlPatterns.SQL_SEP + "SHARE|$))",
         Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 

--- a/src/test/java/org/pjdbc/conformance/ParameterDefaultConformanceTest.java
+++ b/src/test/java/org/pjdbc/conformance/ParameterDefaultConformanceTest.java
@@ -130,9 +130,9 @@ public class ParameterDefaultConformanceTest extends DriverConformanceTest {
             for (DriverCapability.Parameter param : driver.parameters()) {
                 assertNotNull(param.name(), "Parameter name should not be null in " + driver.name());
                 assertFalse(param.name().isEmpty(), "Parameter name should not be empty in " + driver.name());
-                assertTrue(param.name().matches("[a-zA-Z][a-zA-Z0-9_]*"),
+                assertTrue(param.name().matches("[a-zA-Z][a-zA-Z0-9_]*(\\.\\*)?"),
                     "Parameter name '" + param.name() + "' in " + driver.name() +
-                    " should be a valid identifier");
+                    " should be a valid identifier or wildcard pattern");
             }
         }
     }

--- a/src/test/java/org/pjdbc/drivers/SchemaValidationBypassTest.java
+++ b/src/test/java/org/pjdbc/drivers/SchemaValidationBypassTest.java
@@ -1,0 +1,69 @@
+package org.pjdbc.drivers;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SchemaValidationBypassTest {
+
+    private Connection conn;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        Class.forName("org.pjdbc.drivers.SchemaValidationDriver");
+        Class.forName("org.h2.Driver");
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (conn != null && !conn.isClosed()) {
+            conn.close();
+        }
+    }
+
+    @Test
+    void bypassWithCommentsInFrom() throws SQLException {
+        // Whitelist both tables so we can create them, then we'll use a connection with restricted whitelist
+        String urlBase = "jdbc:h2:mem:bypass1;DB_CLOSE_DELAY=-1";
+        try (Connection setupConn = DriverManager.getConnection(urlBase)) {
+            try (Statement stmt = setupConn.createStatement()) {
+                stmt.execute("CREATE TABLE allowed_table (id INT)");
+                stmt.execute("CREATE TABLE secret_table (id INT)");
+            }
+        }
+
+        // Now connect via SchemaValidationDriver with restricted whitelist
+        conn = DriverManager.getConnection(
+            "jdbc:schema[allowedTables=allowed_table]:" + urlBase
+        );
+
+        try (Statement stmt = conn.createStatement()) {
+            // This should be blocked
+            SQLException ex = assertThrows(SQLException.class, () ->
+                stmt.executeQuery("SELECT * FROM secret_table")
+            );
+            assertTrue(ex.getMessage().contains("secret_table"));
+
+            // This should ALSO be blocked, but if it's vulnerable, it will succeed (bypass)
+            try {
+                stmt.executeQuery("SELECT * FROM/**/secret_table");
+                // If it doesn't throw, the bypass worked!
+                fail("Bypass successful: SELECT * FROM/**/secret_table was not blocked");
+            } catch (SQLException e) {
+                if (e.getMessage().contains("secret_table")) {
+                    // It was correctly blocked
+                    return;
+                }
+                // Some other error (e.g. SQL syntax error) - still means it didn't block it as expected
+                throw e;
+            }
+        }
+    }
+}

--- a/src/test/java/org/pjdbc/sql/TransformerCommentTest.java
+++ b/src/test/java/org/pjdbc/sql/TransformerCommentTest.java
@@ -1,0 +1,62 @@
+package org.pjdbc.sql;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Transformers with Comments")
+class TransformerCommentTest {
+
+    @Test
+    @DisplayName("SchemaTransformer handles comments as separators")
+    void schemaTransformerHandlesComments() throws Exception {
+        SchemaTransformer transformer = new SchemaTransformer("tenant123");
+
+        // Block comments
+        assertEquals("SELECT * FROM/**/tenant123.users",
+            transformer.transformSql("SELECT * FROM/**/users"));
+
+        // Line comments
+        String sqlWithLineComment = "SELECT * FROM -- comment\nusers";
+        String expected = "SELECT * FROM -- comment\ntenant123.users";
+        assertEquals(expected, transformer.transformSql(sqlWithLineComment));
+
+        // Multiple separators
+        assertEquals("SELECT * FROM  /**/  tenant123.users",
+            transformer.transformSql("SELECT * FROM  /**/  users"));
+    }
+
+    @Test
+    @DisplayName("WhereTransformer handles leading comments")
+    void whereTransformerHandlesLeadingComments() throws Exception {
+        WhereTransformer transformer = new WhereTransformer("tenant_id=1");
+
+        // Leading block comment
+        assertEquals("/**/SELECT * FROM users WHERE tenant_id=1",
+            transformer.transformSql("/**/SELECT * FROM users"));
+
+        // Leading line comment
+        assertEquals("-- comment\nSELECT * FROM users WHERE tenant_id=1",
+            transformer.transformSql("-- comment\nSELECT * FROM users"));
+
+        // Leading whitespace and comment
+        assertEquals("  /* x */ SELECT * FROM users WHERE tenant_id=1",
+            transformer.transformSql("  /* x */ SELECT * FROM users"));
+    }
+
+    @Test
+    @DisplayName("WhereTransformer handles comments in insertion points")
+    void whereTransformerHandlesCommentsInInsertionPoints() throws Exception {
+        WhereTransformer transformer = new WhereTransformer("active=true");
+
+        // Comment before ORDER BY
+        assertEquals("SELECT * FROM users WHERE active=true/**/ORDER BY name",
+            transformer.transformSql("SELECT * FROM users/**/ORDER BY name"));
+
+        // Comment inside GROUP BY (if it matches)
+        // Note: our regex matches the whole separator before GROUP BY
+        assertEquals("SELECT * FROM users WHERE active=true  -- comment\nGROUP BY id",
+            transformer.transformSql("SELECT * FROM users  -- comment\nGROUP BY id"));
+    }
+}


### PR DESCRIPTION
This PR fixes a security vulnerability where SQL-based security controls could be bypassed using SQL comments. Standard regex patterns using `\s+` fail to match SQL where keywords are separated by comments (e.g., `SELECT * FROM/**/secret_table`). 

Changes:
1. Introduced `org.pjdbc.sql.SqlPatterns` to centralize robust SQL separator regexes.
2. Updated `SchemaValidationDriver` to use these patterns for table and column extraction.
3. Updated `SchemaTransformer` and `WhereTransformer` to handle comments as separators and preserve them during transformation.
4. Added unit tests to verify the fix and prevent regressions.
5. Fixed `ParameterDefaultConformanceTest` to correctly validate wildcard parameter names like `rename.*`.

🚨 Severity: HIGH
💡 Vulnerability: SQL parsing bypass via comments
🎯 Impact: Unauthorized access to blocked tables/columns or bypass of row-level security filters.
🔧 Fix: Use comment-aware regex for SQL separators.
✅ Verification: New test cases in `SchemaValidationBypassTest` and `TransformerCommentTest` specifically target this bypass.

---
*PR created automatically by Jules for task [15526057716232320264](https://jules.google.com/task/15526057716232320264) started by @davidaventimiglia-professional*