### PR TITLE
🛡️ Sentinel: [HIGH] Fix DataMaskingDriver alias bypass and LOB leakage

### DIFF
--- a/src/main/java/org/pjdbc/drivers/DataMaskingDriver.java
+++ b/src/main/java/org/pjdbc/drivers/DataMaskingDriver.java
@@ -475,11 +475,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public String getString(String columnLabel) throws SQLException {
-            String value = super.getString(columnLabel);
-            if (config.shouldMask(columnLabel) && value != null) {
-                return config.maskValue(value);
-            }
-            return value;
+            return getString(findColumn(columnLabel));
         }
 
         @Override
@@ -493,11 +489,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public String getNString(String columnLabel) throws SQLException {
-            String value = super.getNString(columnLabel);
-            if (config.shouldMask(columnLabel) && value != null) {
-                return config.maskValue(value);
-            }
-            return value;
+            return getNString(findColumn(columnLabel));
         }
 
         // === OBJECT METHODS ===
@@ -518,16 +510,36 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public Object getObject(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) {
-                Object value = super.getObject(columnLabel);
-                if (value == null) return null;
-                if (value instanceof String s) {
-                    return config.maskValue(s);
+            return getObject(findColumn(columnLabel));
+        }
+
+        @Override
+        public <T> T getObject(int columnIndex, Class<T> type) throws SQLException {
+            if (shouldMaskColumn(columnIndex)) {
+                if (type == String.class) {
+                    return type.cast(getString(columnIndex));
                 }
-                // Non-string type in masked column - throw to prevent data leak
-                throwMaskedColumnException(columnLabel, "getObject");
+                throwMaskedColumnException(String.valueOf(columnIndex), "getObject");
             }
-            return super.getObject(columnLabel);
+            return super.getObject(columnIndex, type);
+        }
+
+        @Override
+        public <T> T getObject(String columnLabel, Class<T> type) throws SQLException {
+            return getObject(findColumn(columnLabel), type);
+        }
+
+        @Override
+        public Object getObject(int columnIndex, java.util.Map<String, Class<?>> map) throws SQLException {
+            if (shouldMaskColumn(columnIndex)) {
+                throwMaskedColumnException(String.valueOf(columnIndex), "getObject");
+            }
+            return super.getObject(columnIndex, map);
+        }
+
+        @Override
+        public Object getObject(String columnLabel, java.util.Map<String, Class<?>> map) throws SQLException {
+            return getObject(findColumn(columnLabel), map);
         }
 
         // === NUMERIC METHODS - throw SQLException for masked columns ===
@@ -540,8 +552,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public byte getByte(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getByte");
-            return super.getByte(columnLabel);
+            return getByte(findColumn(columnLabel));
         }
 
         @Override
@@ -552,8 +563,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public short getShort(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getShort");
-            return super.getShort(columnLabel);
+            return getShort(findColumn(columnLabel));
         }
 
         @Override
@@ -564,8 +574,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public int getInt(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getInt");
-            return super.getInt(columnLabel);
+            return getInt(findColumn(columnLabel));
         }
 
         @Override
@@ -576,8 +585,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public long getLong(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getLong");
-            return super.getLong(columnLabel);
+            return getLong(findColumn(columnLabel));
         }
 
         @Override
@@ -588,8 +596,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public float getFloat(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getFloat");
-            return super.getFloat(columnLabel);
+            return getFloat(findColumn(columnLabel));
         }
 
         @Override
@@ -600,8 +607,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public double getDouble(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getDouble");
-            return super.getDouble(columnLabel);
+            return getDouble(findColumn(columnLabel));
         }
 
         @Override
@@ -612,8 +618,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public java.math.BigDecimal getBigDecimal(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getBigDecimal");
-            return super.getBigDecimal(columnLabel);
+            return getBigDecimal(findColumn(columnLabel));
         }
 
         @Override
@@ -626,8 +631,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
         @Override
         @SuppressWarnings("deprecation")
         public java.math.BigDecimal getBigDecimal(String columnLabel, int scale) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getBigDecimal");
-            return super.getBigDecimal(columnLabel, scale);
+            return getBigDecimal(findColumn(columnLabel), scale);
         }
 
         // === BYTES - return masked string as bytes ===
@@ -644,12 +648,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public byte[] getBytes(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) {
-                String value = super.getString(columnLabel);
-                if (value == null) return null;
-                return config.maskValue(value).getBytes(java.nio.charset.StandardCharsets.UTF_8);
-            }
-            return super.getBytes(columnLabel);
+            return getBytes(findColumn(columnLabel));
         }
 
         // === BOOLEAN - throw SQLException for masked columns ===
@@ -662,8 +661,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public boolean getBoolean(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getBoolean");
-            return super.getBoolean(columnLabel);
+            return getBoolean(findColumn(columnLabel));
         }
 
         // === DATE/TIME METHODS - throw SQLException for masked columns ===
@@ -676,8 +674,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public java.sql.Date getDate(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getDate");
-            return super.getDate(columnLabel);
+            return getDate(findColumn(columnLabel));
         }
 
         @Override
@@ -688,8 +685,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public java.sql.Date getDate(String columnLabel, java.util.Calendar cal) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getDate");
-            return super.getDate(columnLabel, cal);
+            return getDate(findColumn(columnLabel), cal);
         }
 
         @Override
@@ -700,8 +696,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public java.sql.Time getTime(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getTime");
-            return super.getTime(columnLabel);
+            return getTime(findColumn(columnLabel));
         }
 
         @Override
@@ -712,8 +707,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public java.sql.Time getTime(String columnLabel, java.util.Calendar cal) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getTime");
-            return super.getTime(columnLabel, cal);
+            return getTime(findColumn(columnLabel), cal);
         }
 
         @Override
@@ -724,8 +718,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public java.sql.Timestamp getTimestamp(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getTimestamp");
-            return super.getTimestamp(columnLabel);
+            return getTimestamp(findColumn(columnLabel));
         }
 
         @Override
@@ -736,8 +729,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public java.sql.Timestamp getTimestamp(String columnLabel, java.util.Calendar cal) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getTimestamp");
-            return super.getTimestamp(columnLabel, cal);
+            return getTimestamp(findColumn(columnLabel), cal);
         }
 
         // === CHARACTER STREAMS - return stream of masked content ===
@@ -754,12 +746,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public java.io.Reader getCharacterStream(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) {
-                String value = super.getString(columnLabel);
-                if (value == null) return null;
-                return new java.io.StringReader(config.maskValue(value));
-            }
-            return super.getCharacterStream(columnLabel);
+            return getCharacterStream(findColumn(columnLabel));
         }
 
         @Override
@@ -774,12 +761,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public java.io.Reader getNCharacterStream(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) {
-                String value = super.getNString(columnLabel);
-                if (value == null) return null;
-                return new java.io.StringReader(config.maskValue(value));
-            }
-            return super.getNCharacterStream(columnLabel);
+            return getNCharacterStream(findColumn(columnLabel));
         }
 
         // === BINARY STREAMS - return stream of masked bytes ===
@@ -797,13 +779,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public java.io.InputStream getAsciiStream(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) {
-                String value = super.getString(columnLabel);
-                if (value == null) return null;
-                byte[] maskedBytes = config.maskValue(value).getBytes(java.nio.charset.StandardCharsets.US_ASCII);
-                return new java.io.ByteArrayInputStream(maskedBytes);
-            }
-            return super.getAsciiStream(columnLabel);
+            return getAsciiStream(findColumn(columnLabel));
         }
 
         @Override
@@ -819,13 +795,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public java.io.InputStream getBinaryStream(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) {
-                String value = super.getString(columnLabel);
-                if (value == null) return null;
-                byte[] maskedBytes = config.maskValue(value).getBytes(java.nio.charset.StandardCharsets.UTF_8);
-                return new java.io.ByteArrayInputStream(maskedBytes);
-            }
-            return super.getBinaryStream(columnLabel);
+            return getBinaryStream(findColumn(columnLabel));
         }
 
         @Override
@@ -843,13 +813,97 @@ public class DataMaskingDriver extends AbstractProxyDriver {
         @Override
         @SuppressWarnings("deprecation")
         public java.io.InputStream getUnicodeStream(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) {
-                String value = super.getString(columnLabel);
-                if (value == null) return null;
-                byte[] maskedBytes = config.maskValue(value).getBytes(java.nio.charset.StandardCharsets.UTF_16);
-                return new java.io.ByteArrayInputStream(maskedBytes);
-            }
-            return super.getUnicodeStream(columnLabel);
+            return getUnicodeStream(findColumn(columnLabel));
+        }
+
+        // === COMPLEX TYPES - throw SQLException for masked columns ===
+
+        @Override
+        public java.sql.Blob getBlob(int columnIndex) throws SQLException {
+            if (shouldMaskColumn(columnIndex)) throwMaskedColumnException(String.valueOf(columnIndex), "getBlob");
+            return super.getBlob(columnIndex);
+        }
+
+        @Override
+        public java.sql.Blob getBlob(String columnLabel) throws SQLException {
+            return getBlob(findColumn(columnLabel));
+        }
+
+        @Override
+        public java.sql.Clob getClob(int columnIndex) throws SQLException {
+            if (shouldMaskColumn(columnIndex)) throwMaskedColumnException(String.valueOf(columnIndex), "getClob");
+            return super.getClob(columnIndex);
+        }
+
+        @Override
+        public java.sql.Clob getClob(String columnLabel) throws SQLException {
+            return getClob(findColumn(columnLabel));
+        }
+
+        @Override
+        public java.sql.NClob getNClob(int columnIndex) throws SQLException {
+            if (shouldMaskColumn(columnIndex)) throwMaskedColumnException(String.valueOf(columnIndex), "getNClob");
+            return super.getNClob(columnIndex);
+        }
+
+        @Override
+        public java.sql.NClob getNClob(String columnLabel) throws SQLException {
+            return getNClob(findColumn(columnLabel));
+        }
+
+        @Override
+        public java.sql.Array getArray(int columnIndex) throws SQLException {
+            if (shouldMaskColumn(columnIndex)) throwMaskedColumnException(String.valueOf(columnIndex), "getArray");
+            return super.getArray(columnIndex);
+        }
+
+        @Override
+        public java.sql.Array getArray(String columnLabel) throws SQLException {
+            return getArray(findColumn(columnLabel));
+        }
+
+        @Override
+        public java.sql.Ref getRef(int columnIndex) throws SQLException {
+            if (shouldMaskColumn(columnIndex)) throwMaskedColumnException(String.valueOf(columnIndex), "getRef");
+            return super.getRef(columnIndex);
+        }
+
+        @Override
+        public java.sql.Ref getRef(String columnLabel) throws SQLException {
+            return getRef(findColumn(columnLabel));
+        }
+
+        @Override
+        public java.net.URL getURL(int columnIndex) throws SQLException {
+            if (shouldMaskColumn(columnIndex)) throwMaskedColumnException(String.valueOf(columnIndex), "getURL");
+            return super.getURL(columnIndex);
+        }
+
+        @Override
+        public java.net.URL getURL(String columnLabel) throws SQLException {
+            return getURL(findColumn(columnLabel));
+        }
+
+        @Override
+        public java.sql.RowId getRowId(int columnIndex) throws SQLException {
+            if (shouldMaskColumn(columnIndex)) throwMaskedColumnException(String.valueOf(columnIndex), "getRowId");
+            return super.getRowId(columnIndex);
+        }
+
+        @Override
+        public java.sql.RowId getRowId(String columnLabel) throws SQLException {
+            return getRowId(findColumn(columnLabel));
+        }
+
+        @Override
+        public java.sql.SQLXML getSQLXML(int columnIndex) throws SQLException {
+            if (shouldMaskColumn(columnIndex)) throwMaskedColumnException(String.valueOf(columnIndex), "getSQLXML");
+            return super.getSQLXML(columnIndex);
+        }
+
+        @Override
+        public java.sql.SQLXML getSQLXML(String columnLabel) throws SQLException {
+            return getSQLXML(findColumn(columnLabel));
         }
     }
 }

--- a/src/test/java/org/pjdbc/conformance/ParameterDefaultConformanceTest.java
+++ b/src/test/java/org/pjdbc/conformance/ParameterDefaultConformanceTest.java
@@ -130,9 +130,9 @@ public class ParameterDefaultConformanceTest extends DriverConformanceTest {
             for (DriverCapability.Parameter param : driver.parameters()) {
                 assertNotNull(param.name(), "Parameter name should not be null in " + driver.name());
                 assertFalse(param.name().isEmpty(), "Parameter name should not be empty in " + driver.name());
-                assertTrue(param.name().matches("[a-zA-Z][a-zA-Z0-9_]*"),
+                assertTrue(param.name().matches("[a-zA-Z][a-zA-Z0-9_]*(\\.\\*)?"),
                     "Parameter name '" + param.name() + "' in " + driver.name() +
-                    " should be a valid identifier");
+                    " should be a valid identifier or wildcard pattern");
             }
         }
     }

--- a/src/test/java/org/pjdbc/drivers/DataMaskingBypassTest.java
+++ b/src/test/java/org/pjdbc/drivers/DataMaskingBypassTest.java
@@ -1,0 +1,106 @@
+package org.pjdbc.drivers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.sql.Blob;
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class DataMaskingBypassTest {
+
+    @BeforeClass
+    public static void loadDriver() throws ClassNotFoundException {
+        Class.forName("org.pjdbc.drivers.DataMaskingDriver");
+    }
+
+    private void setupTestTable(String dbName) throws SQLException {
+        try (Connection conn = DriverManager.getConnection("jdbc:h2:mem:" + dbName + ";DB_CLOSE_DELAY=-1")) {
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute("CREATE TABLE users (id INT PRIMARY KEY, ssn VARCHAR(11))");
+                stmt.execute("INSERT INTO users VALUES (1, '123-45-6789')");
+
+                stmt.execute("CREATE TABLE lob_data (id INT PRIMARY KEY, secret_blob BLOB, secret_clob CLOB)");
+                stmt.execute("INSERT INTO lob_data VALUES (1, CAST('secret blob' AS BLOB), CAST('secret clob' AS CLOB))");
+            }
+        }
+    }
+
+    @Test
+    public void testAliasBypass() throws SQLException {
+        setupTestTable("test_alias_bypass");
+        // Only ssn is masked
+        String url = "jdbc:mask[columns=ssn,strategy=REDACT]:jdbc:h2:mem:test_alias_bypass;DB_CLOSE_DELAY=-1";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                // Using an alias that does NOT match the 'ssn' pattern
+                try (ResultSet rs = stmt.executeQuery("SELECT ssn AS my_alias FROM users WHERE id = 1")) {
+                    assertTrue(rs.next());
+                    String value = rs.getString("my_alias");
+                    if ("123-45-6789".equals(value)) {
+                        fail("Bypass detected! Able to retrieve masked data via alias: " + value);
+                    }
+                    assertEquals("[REDACTED]", value);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testGetBlobMaskedBypass() throws SQLException {
+        setupTestTable("test_blob_bypass");
+        String url = "jdbc:mask[columns=secret_blob]:jdbc:h2:mem:test_blob_bypass;DB_CLOSE_DELAY=-1";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                try (ResultSet rs = stmt.executeQuery("SELECT secret_blob FROM lob_data WHERE id = 1")) {
+                    assertTrue(rs.next());
+                    try {
+                        Blob blob = rs.getBlob("secret_blob");
+                        if (blob != null) {
+                            byte[] bytes = blob.getBytes(1, (int) blob.length());
+                            String value = new String(bytes);
+                            if ("secret blob".equals(value)) {
+                                fail("Bypass detected! Able to retrieve masked BLOB data.");
+                            }
+                        }
+                    } catch (SQLException e) {
+                        // Expected if fixed
+                        assertTrue(e.getMessage().contains("masked"));
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testGetClobMaskedBypass() throws SQLException {
+        setupTestTable("test_clob_bypass");
+        String url = "jdbc:mask[columns=secret_clob]:jdbc:h2:mem:test_clob_bypass;DB_CLOSE_DELAY=-1";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                try (ResultSet rs = stmt.executeQuery("SELECT secret_clob FROM lob_data WHERE id = 1")) {
+                    assertTrue(rs.next());
+                    try {
+                        Clob clob = rs.getClob("secret_clob");
+                        if (clob != null) {
+                            String value = clob.getSubString(1, (int) clob.length());
+                            if ("secret clob".equals(value)) {
+                                fail("Bypass detected! Able to retrieve masked CLOB data.");
+                            }
+                        }
+                    } catch (SQLException e) {
+                        // Expected if fixed
+                        assertTrue(e.getMessage().contains("masked"));
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR addresses a high-severity security vulnerability in the `DataMaskingDriver` where masking could be bypassed using SQL column aliases (e.g., `SELECT sensitive_col AS alias`). 

Previously, the driver matched masking patterns against the column label provided in the getter method. By using an alias, an attacker could bypass this check. The fix refactors all label-based getter methods to resolve the underlying column index via `findColumn(label)` and delegate to index-based getters, which use a pre-computed bitmask of sensitive columns.

Additionally, this PR enhances the `DataMaskingDriver` by closing gaps in LOB and complex type coverage. Methods like `getBlob`, `getClob`, and `getArray` now correctly identify masked columns and throw an `SQLException`, following the "fail-secure" principle.

Finally, a regression in `ParameterDefaultConformanceTest` was fixed to allow the `FilterDriver`'s wildcard parameters (e.g., `rename.*`) to pass validation.

Verified with a new test suite `DataMaskingBypassTest.java` and by running the full project test suite.

---
*PR created automatically by Jules for task [7657388999714085596](https://jules.google.com/task/7657388999714085596) started by @davidaventimiglia-professional*