### PR TITLE
🛡️ Sentinel: [HIGH] Fix LOB and Alias bypasses in DataMaskingDriver

### DIFF
--- a/src/main/java/org/pjdbc/drivers/DataMaskingDriver.java
+++ b/src/main/java/org/pjdbc/drivers/DataMaskingDriver.java
@@ -475,11 +475,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public String getString(String columnLabel) throws SQLException {
-            String value = super.getString(columnLabel);
-            if (config.shouldMask(columnLabel) && value != null) {
-                return config.maskValue(value);
-            }
-            return value;
+            return getString(findColumn(columnLabel));
         }
 
         @Override
@@ -493,11 +489,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public String getNString(String columnLabel) throws SQLException {
-            String value = super.getNString(columnLabel);
-            if (config.shouldMask(columnLabel) && value != null) {
-                return config.maskValue(value);
-            }
-            return value;
+            return getNString(findColumn(columnLabel));
         }
 
         // === OBJECT METHODS ===
@@ -518,16 +510,41 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public Object getObject(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) {
-                Object value = super.getObject(columnLabel);
-                if (value == null) return null;
+            return getObject(findColumn(columnLabel));
+        }
+
+        @Override
+        public Object getObject(int columnIndex, java.util.Map<String, Class<?>> map) throws SQLException {
+            Object value = super.getObject(columnIndex, map);
+            if (shouldMaskColumn(columnIndex) && value != null) {
                 if (value instanceof String s) {
                     return config.maskValue(s);
                 }
-                // Non-string type in masked column - throw to prevent data leak
-                throwMaskedColumnException(columnLabel, "getObject");
+                throwMaskedColumnException(String.valueOf(columnIndex), "getObject");
             }
-            return super.getObject(columnLabel);
+            return value;
+        }
+
+        @Override
+        public Object getObject(String columnLabel, java.util.Map<String, Class<?>> map) throws SQLException {
+            return getObject(findColumn(columnLabel), map);
+        }
+
+        @Override
+        public <T> T getObject(int columnIndex, Class<T> type) throws SQLException {
+            if (shouldMaskColumn(columnIndex)) {
+                if (type == String.class) {
+                    return type.cast(getString(columnIndex));
+                }
+                if (super.getObject(columnIndex) == null) return null;
+                throwMaskedColumnException(String.valueOf(columnIndex), "getObject");
+            }
+            return super.getObject(columnIndex, type);
+        }
+
+        @Override
+        public <T> T getObject(String columnLabel, Class<T> type) throws SQLException {
+            return getObject(findColumn(columnLabel), type);
         }
 
         // === NUMERIC METHODS - throw SQLException for masked columns ===
@@ -540,8 +557,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public byte getByte(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getByte");
-            return super.getByte(columnLabel);
+            return getByte(findColumn(columnLabel));
         }
 
         @Override
@@ -552,8 +568,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public short getShort(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getShort");
-            return super.getShort(columnLabel);
+            return getShort(findColumn(columnLabel));
         }
 
         @Override
@@ -564,8 +579,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public int getInt(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getInt");
-            return super.getInt(columnLabel);
+            return getInt(findColumn(columnLabel));
         }
 
         @Override
@@ -576,8 +590,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public long getLong(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getLong");
-            return super.getLong(columnLabel);
+            return getLong(findColumn(columnLabel));
         }
 
         @Override
@@ -588,8 +601,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public float getFloat(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getFloat");
-            return super.getFloat(columnLabel);
+            return getFloat(findColumn(columnLabel));
         }
 
         @Override
@@ -600,8 +612,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public double getDouble(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getDouble");
-            return super.getDouble(columnLabel);
+            return getDouble(findColumn(columnLabel));
         }
 
         @Override
@@ -612,8 +623,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public java.math.BigDecimal getBigDecimal(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getBigDecimal");
-            return super.getBigDecimal(columnLabel);
+            return getBigDecimal(findColumn(columnLabel));
         }
 
         @Override
@@ -626,8 +636,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
         @Override
         @SuppressWarnings("deprecation")
         public java.math.BigDecimal getBigDecimal(String columnLabel, int scale) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getBigDecimal");
-            return super.getBigDecimal(columnLabel, scale);
+            return getBigDecimal(findColumn(columnLabel), scale);
         }
 
         // === BYTES - return masked string as bytes ===
@@ -644,12 +653,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public byte[] getBytes(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) {
-                String value = super.getString(columnLabel);
-                if (value == null) return null;
-                return config.maskValue(value).getBytes(java.nio.charset.StandardCharsets.UTF_8);
-            }
-            return super.getBytes(columnLabel);
+            return getBytes(findColumn(columnLabel));
         }
 
         // === BOOLEAN - throw SQLException for masked columns ===
@@ -662,8 +666,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public boolean getBoolean(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getBoolean");
-            return super.getBoolean(columnLabel);
+            return getBoolean(findColumn(columnLabel));
         }
 
         // === DATE/TIME METHODS - throw SQLException for masked columns ===
@@ -676,8 +679,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public java.sql.Date getDate(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getDate");
-            return super.getDate(columnLabel);
+            return getDate(findColumn(columnLabel));
         }
 
         @Override
@@ -688,8 +690,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public java.sql.Date getDate(String columnLabel, java.util.Calendar cal) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getDate");
-            return super.getDate(columnLabel, cal);
+            return getDate(findColumn(columnLabel), cal);
         }
 
         @Override
@@ -700,8 +701,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public java.sql.Time getTime(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getTime");
-            return super.getTime(columnLabel);
+            return getTime(findColumn(columnLabel));
         }
 
         @Override
@@ -712,8 +712,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public java.sql.Time getTime(String columnLabel, java.util.Calendar cal) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getTime");
-            return super.getTime(columnLabel, cal);
+            return getTime(findColumn(columnLabel), cal);
         }
 
         @Override
@@ -724,8 +723,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public java.sql.Timestamp getTimestamp(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getTimestamp");
-            return super.getTimestamp(columnLabel);
+            return getTimestamp(findColumn(columnLabel));
         }
 
         @Override
@@ -736,8 +734,121 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public java.sql.Timestamp getTimestamp(String columnLabel, java.util.Calendar cal) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getTimestamp");
-            return super.getTimestamp(columnLabel, cal);
+            return getTimestamp(findColumn(columnLabel), cal);
+        }
+
+        // === ADVANCED TYPES - throw SQLException for masked columns ===
+
+        @Override
+        public java.sql.Blob getBlob(int columnIndex) throws SQLException {
+            java.sql.Blob value = super.getBlob(columnIndex);
+            if (shouldMaskColumn(columnIndex) && value != null) {
+                throwMaskedColumnException(String.valueOf(columnIndex), "getBlob");
+            }
+            return value;
+        }
+
+        @Override
+        public java.sql.Blob getBlob(String columnLabel) throws SQLException {
+            return getBlob(findColumn(columnLabel));
+        }
+
+        @Override
+        public java.sql.Clob getClob(int columnIndex) throws SQLException {
+            java.sql.Clob value = super.getClob(columnIndex);
+            if (shouldMaskColumn(columnIndex) && value != null) {
+                throwMaskedColumnException(String.valueOf(columnIndex), "getClob");
+            }
+            return value;
+        }
+
+        @Override
+        public java.sql.Clob getClob(String columnLabel) throws SQLException {
+            return getClob(findColumn(columnLabel));
+        }
+
+        @Override
+        public java.sql.NClob getNClob(int columnIndex) throws SQLException {
+            java.sql.NClob value = super.getNClob(columnIndex);
+            if (shouldMaskColumn(columnIndex) && value != null) {
+                throwMaskedColumnException(String.valueOf(columnIndex), "getNClob");
+            }
+            return value;
+        }
+
+        @Override
+        public java.sql.NClob getNClob(String columnLabel) throws SQLException {
+            return getNClob(findColumn(columnLabel));
+        }
+
+        @Override
+        public java.sql.Array getArray(int columnIndex) throws SQLException {
+            java.sql.Array value = super.getArray(columnIndex);
+            if (shouldMaskColumn(columnIndex) && value != null) {
+                throwMaskedColumnException(String.valueOf(columnIndex), "getArray");
+            }
+            return value;
+        }
+
+        @Override
+        public java.sql.Array getArray(String columnLabel) throws SQLException {
+            return getArray(findColumn(columnLabel));
+        }
+
+        @Override
+        public java.sql.Ref getRef(int columnIndex) throws SQLException {
+            java.sql.Ref value = super.getRef(columnIndex);
+            if (shouldMaskColumn(columnIndex) && value != null) {
+                throwMaskedColumnException(String.valueOf(columnIndex), "getRef");
+            }
+            return value;
+        }
+
+        @Override
+        public java.sql.Ref getRef(String columnLabel) throws SQLException {
+            return getRef(findColumn(columnLabel));
+        }
+
+        @Override
+        public java.net.URL getURL(int columnIndex) throws SQLException {
+            java.net.URL value = super.getURL(columnIndex);
+            if (shouldMaskColumn(columnIndex) && value != null) {
+                throwMaskedColumnException(String.valueOf(columnIndex), "getURL");
+            }
+            return value;
+        }
+
+        @Override
+        public java.net.URL getURL(String columnLabel) throws SQLException {
+            return getURL(findColumn(columnLabel));
+        }
+
+        @Override
+        public java.sql.RowId getRowId(int columnIndex) throws SQLException {
+            java.sql.RowId value = super.getRowId(columnIndex);
+            if (shouldMaskColumn(columnIndex) && value != null) {
+                throwMaskedColumnException(String.valueOf(columnIndex), "getRowId");
+            }
+            return value;
+        }
+
+        @Override
+        public java.sql.RowId getRowId(String columnLabel) throws SQLException {
+            return getRowId(findColumn(columnLabel));
+        }
+
+        @Override
+        public java.sql.SQLXML getSQLXML(int columnIndex) throws SQLException {
+            java.sql.SQLXML value = super.getSQLXML(columnIndex);
+            if (shouldMaskColumn(columnIndex) && value != null) {
+                throwMaskedColumnException(String.valueOf(columnIndex), "getSQLXML");
+            }
+            return value;
+        }
+
+        @Override
+        public java.sql.SQLXML getSQLXML(String columnLabel) throws SQLException {
+            return getSQLXML(findColumn(columnLabel));
         }
 
         // === CHARACTER STREAMS - return stream of masked content ===
@@ -754,12 +865,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public java.io.Reader getCharacterStream(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) {
-                String value = super.getString(columnLabel);
-                if (value == null) return null;
-                return new java.io.StringReader(config.maskValue(value));
-            }
-            return super.getCharacterStream(columnLabel);
+            return getCharacterStream(findColumn(columnLabel));
         }
 
         @Override
@@ -774,12 +880,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public java.io.Reader getNCharacterStream(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) {
-                String value = super.getNString(columnLabel);
-                if (value == null) return null;
-                return new java.io.StringReader(config.maskValue(value));
-            }
-            return super.getNCharacterStream(columnLabel);
+            return getNCharacterStream(findColumn(columnLabel));
         }
 
         // === BINARY STREAMS - return stream of masked bytes ===
@@ -797,13 +898,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public java.io.InputStream getAsciiStream(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) {
-                String value = super.getString(columnLabel);
-                if (value == null) return null;
-                byte[] maskedBytes = config.maskValue(value).getBytes(java.nio.charset.StandardCharsets.US_ASCII);
-                return new java.io.ByteArrayInputStream(maskedBytes);
-            }
-            return super.getAsciiStream(columnLabel);
+            return getAsciiStream(findColumn(columnLabel));
         }
 
         @Override
@@ -819,13 +914,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public java.io.InputStream getBinaryStream(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) {
-                String value = super.getString(columnLabel);
-                if (value == null) return null;
-                byte[] maskedBytes = config.maskValue(value).getBytes(java.nio.charset.StandardCharsets.UTF_8);
-                return new java.io.ByteArrayInputStream(maskedBytes);
-            }
-            return super.getBinaryStream(columnLabel);
+            return getBinaryStream(findColumn(columnLabel));
         }
 
         @Override
@@ -843,13 +932,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
         @Override
         @SuppressWarnings("deprecation")
         public java.io.InputStream getUnicodeStream(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) {
-                String value = super.getString(columnLabel);
-                if (value == null) return null;
-                byte[] maskedBytes = config.maskValue(value).getBytes(java.nio.charset.StandardCharsets.UTF_16);
-                return new java.io.ByteArrayInputStream(maskedBytes);
-            }
-            return super.getUnicodeStream(columnLabel);
+            return getUnicodeStream(findColumn(columnLabel));
         }
     }
 }

--- a/src/test/java/org/pjdbc/conformance/ParameterDefaultConformanceTest.java
+++ b/src/test/java/org/pjdbc/conformance/ParameterDefaultConformanceTest.java
@@ -130,9 +130,9 @@ public class ParameterDefaultConformanceTest extends DriverConformanceTest {
             for (DriverCapability.Parameter param : driver.parameters()) {
                 assertNotNull(param.name(), "Parameter name should not be null in " + driver.name());
                 assertFalse(param.name().isEmpty(), "Parameter name should not be empty in " + driver.name());
-                assertTrue(param.name().matches("[a-zA-Z][a-zA-Z0-9_]*"),
+                assertTrue(param.name().matches("[a-zA-Z][a-zA-Z0-9_]*(\\.\\*)?"),
                     "Parameter name '" + param.name() + "' in " + driver.name() +
-                    " should be a valid identifier");
+                    " should be a valid identifier or wildcard pattern");
             }
         }
     }

--- a/src/test/java/org/pjdbc/drivers/DataMaskingSecurityTest.java
+++ b/src/test/java/org/pjdbc/drivers/DataMaskingSecurityTest.java
@@ -1,0 +1,97 @@
+package org.pjdbc.drivers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.sql.Blob;
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class DataMaskingSecurityTest {
+
+    @BeforeClass
+    public static void loadDriver() throws ClassNotFoundException {
+        Class.forName("org.pjdbc.drivers.DataMaskingDriver");
+    }
+
+    private void setupSecurityTable(String dbName) throws SQLException {
+        try (Connection conn = DriverManager.getConnection("jdbc:h2:mem:" + dbName + ";DB_CLOSE_DELAY=-1")) {
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute("CREATE TABLE IF NOT EXISTS secure_data (" +
+                    "id INT PRIMARY KEY, " +
+                    "ssn VARCHAR(11), " +
+                    "secret_blob BLOB, " +
+                    "secret_clob CLOB)");
+                stmt.execute("INSERT INTO secure_data VALUES (1, '123-45-6789', " +
+                    "CAST('secret binary' AS BLOB), CAST('secret text' AS CLOB))");
+            }
+        }
+    }
+
+    @Test
+    public void testAliasBypass() throws SQLException {
+        setupSecurityTable("test_alias_bypass");
+        String url = "jdbc:mask[columns=ssn,strategy=REDACT]:jdbc:h2:mem:test_alias_bypass;DB_CLOSE_DELAY=-1";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                try (ResultSet rs = stmt.executeQuery("SELECT ssn AS alias_name FROM secure_data WHERE id = 1")) {
+                    assertTrue(rs.next());
+                    String val = rs.getString("alias_name");
+                    if (!"[REDACTED]".equals(val)) {
+                        fail("Vulnerability: Alias bypass detected! Expected [REDACTED] but got: " + val);
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testBlobBypass() throws SQLException {
+        setupSecurityTable("test_blob_bypass");
+        String url = "jdbc:mask[columns=secret_blob]:jdbc:h2:mem:test_blob_bypass;DB_CLOSE_DELAY=-1";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                try (ResultSet rs = stmt.executeQuery("SELECT secret_blob FROM secure_data WHERE id = 1")) {
+                    assertTrue(rs.next());
+                    try {
+                        Blob blob = rs.getBlob("secret_blob");
+                        byte[] bytes = blob.getBytes(1, (int) blob.length());
+                        fail("Vulnerability: BLOB bypass detected! Got: " + new String(bytes));
+                    } catch (SQLException e) {
+                        assertTrue("Expected message to contain 'masked', got: " + e.getMessage(),
+                                   e.getMessage().contains("masked"));
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testClobBypass() throws SQLException {
+        setupSecurityTable("test_clob_bypass");
+        String url = "jdbc:mask[columns=secret_clob]:jdbc:h2:mem:test_clob_bypass;DB_CLOSE_DELAY=-1";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                try (ResultSet rs = stmt.executeQuery("SELECT secret_clob FROM secure_data WHERE id = 1")) {
+                    assertTrue(rs.next());
+                    try {
+                        Clob clob = rs.getClob("secret_clob");
+                        String data = clob.getSubString(1, (int) clob.length());
+                        fail("Vulnerability: CLOB bypass detected! Got: " + data);
+                    } catch (SQLException e) {
+                        assertTrue("Expected message to contain 'masked', got: " + e.getMessage(),
+                                   e.getMessage().contains("masked"));
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Identified and fixed multiple security vulnerabilities in the `DataMaskingDriver` where sensitive data could be retrieved from masked columns using SQL aliases or advanced JDBC getters (like `getBlob`, `getClob`). 

The fix involves:
1. Refactoring all label-based getter methods in `MaskingResultSet` to resolve the column index via `findColumn` and delegate to the index-based counterpart. This ensures that even if a column is aliased in the SQL (e.g., `SELECT secret AS public`), it is correctly identified as masked based on its metadata.
2. Implementing "fail-secure" behavior for non-string types. Since these cannot be easily masked into their original type without losing meaning or causing application errors, we throw a `SQLException` if a masked column is accessed via these getters. Users are encouraged to use `getString()` to retrieve the masked representation.
3. Overriding missing getters for advanced JDBC types like `Blob`, `Clob`, `NClob`, `Array`, `Ref`, `URL`, `RowId`, and `SQLXML` to prevent bypass.
4. Correcting a conformance test that was incorrectly failing on valid wildcard parameter names used by the `FilterDriver`.

Verified the fix with a new `DataMaskingSecurityTest` and ensured no regressions with the full project test suite.

---
*PR created automatically by Jules for task [17919051412833874464](https://jules.google.com/task/17919051412833874464) started by @davidaventimiglia-professional*