### PR TITLE
🛡️ Sentinel: [security improvement] Harden SQL regex parsing against comment and CTE bypasses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-17 - [Comment-aware SQL regex parsing]
+**Vulnerability:** Security-focused regex patterns (e.g., `^\\s*`) were bypassed by placing SQL comments (`/**/` or `--`) at the start of statements or between keywords and identifiers.
+**Learning:** Standard whitespace matches (`\\s`) do not account for SQL comments, which are valid separators. Proxy drivers like `ReadonlyDriver` and `SchemaValidationDriver` were vulnerable to simple comment-based bypasses.
+**Prevention:** Use centralized, comment-aware SQL separator regexes (`SqlPatterns.SQL_SEP` and `SQL_SEP_OPT`) and ensure statement-detection patterns are anchored and account for leading comments.

--- a/src/main/java/org/pjdbc/drivers/ReadonlyDriver.java
+++ b/src/main/java/org/pjdbc/drivers/ReadonlyDriver.java
@@ -11,6 +11,7 @@ import java.sql.Statement;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
+import org.pjdbc.sql.SqlPatterns;
 import org.pjdbc.annotations.DriverCapability;
 import org.pjdbc.annotations.DriverParameter;
 import org.pjdbc.annotations.DriverParameter.ParameterType;
@@ -56,19 +57,19 @@ public class ReadonlyDriver extends AbstractProxyDriver {
 
     // Pattern to detect DML write operations
     private static final Pattern DML_PATTERN = Pattern.compile(
-        "^\\s*(INSERT|UPDATE|DELETE|MERGE|UPSERT|REPLACE|TRUNCATE)\\b",
+        "^" + SqlPatterns.SQL_SEP_OPT + "(WITH|INSERT|UPDATE|DELETE|MERGE|UPSERT|REPLACE|TRUNCATE)\\b",
         Pattern.CASE_INSENSITIVE
     );
 
     // Pattern to detect DDL operations
     private static final Pattern DDL_PATTERN = Pattern.compile(
-        "^\\s*(CREATE|ALTER|DROP|RENAME)\\b",
+        "^" + SqlPatterns.SQL_SEP_OPT + "(CREATE|ALTER|DROP|RENAME)\\b",
         Pattern.CASE_INSENSITIVE
     );
 
     // Pattern to detect DCL operations
     private static final Pattern DCL_PATTERN = Pattern.compile(
-        "^\\s*(GRANT|REVOKE)\\b",
+        "^" + SqlPatterns.SQL_SEP_OPT + "(GRANT|REVOKE)\\b",
         Pattern.CASE_INSENSITIVE
     );
 

--- a/src/main/java/org/pjdbc/drivers/SchemaValidationDriver.java
+++ b/src/main/java/org/pjdbc/drivers/SchemaValidationDriver.java
@@ -18,6 +18,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.pjdbc.sql.SqlPatterns;
 import org.pjdbc.annotations.DriverCapability;
 import org.pjdbc.annotations.DriverParameter;
 import org.pjdbc.annotations.DriverParameter.ParameterType;
@@ -79,25 +80,25 @@ public class SchemaValidationDriver extends AbstractProxyDriver {
     // Pattern to extract table names from SQL
     // Matches: FROM table, JOIN table, INTO table, UPDATE table, TABLE table (for TRUNCATE)
     private static final Pattern TABLE_PATTERN = Pattern.compile(
-        "\\b(?:FROM|JOIN|INTO|UPDATE|TABLE|TRUNCATE)\\s+([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)?)",
+        "\\b(FROM|JOIN|INTO|UPDATE|TABLE|TRUNCATE)" + SqlPatterns.SQL_SEP + "([a-zA-Z_][a-zA-Z0-9_.]*(?:" + SqlPatterns.SQL_SEP_OPT + "," + SqlPatterns.SQL_SEP_OPT + "[a-zA-Z_][a-zA-Z0-9_.]*)*)",
         Pattern.CASE_INSENSITIVE
     );
 
     // Pattern to extract column names from SELECT
     private static final Pattern SELECT_COLUMNS_PATTERN = Pattern.compile(
-        "\\bSELECT\\s+(.+?)\\s+FROM\\b",
+        "\\bSELECT" + SqlPatterns.SQL_SEP + "(.+?)" + SqlPatterns.SQL_SEP + "FROM\\b",
         Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to extract columns from INSERT
     private static final Pattern INSERT_COLUMNS_PATTERN = Pattern.compile(
-        "\\bINSERT\\s+INTO\\s+[a-zA-Z_][a-zA-Z0-9_.]*\\s*\\(([^)]+)\\)",
+        "\\bINSERT" + SqlPatterns.SQL_SEP + "INTO" + SqlPatterns.SQL_SEP + "[a-zA-Z_][a-zA-Z0-9_.]*" + SqlPatterns.SQL_SEP_OPT + "\\(([^)]+)\\)",
         Pattern.CASE_INSENSITIVE
     );
 
     // Pattern to extract columns from UPDATE SET
     private static final Pattern UPDATE_COLUMNS_PATTERN = Pattern.compile(
-        "\\bSET\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
+        "\\bSET" + SqlPatterns.SQL_SEP + "([a-zA-Z_][a-zA-Z0-9_]*)",
         Pattern.CASE_INSENSITIVE
     );
 
@@ -302,12 +303,17 @@ public class SchemaValidationDriver extends AbstractProxyDriver {
             Set<String> tables = new HashSet<>();
             Matcher matcher = TABLE_PATTERN.matcher(sql);
             while (matcher.find()) {
-                String table = matcher.group(1);
-                // Handle schema.table format - extract just table name
-                if (table.contains(".")) {
-                    table = table.substring(table.lastIndexOf('.') + 1);
+                String tableList = matcher.group(2);
+                for (String part : tableList.split(",")) {
+                    // Remove comments and trim
+                    String table = part.replaceAll(SqlPatterns.SQL_COMMENT, "").trim();
+                    if (table.isEmpty()) continue;
+                    // Handle schema.table format - extract just table name
+                    if (table.contains(".")) {
+                        table = table.substring(table.lastIndexOf('.') + 1);
+                    }
+                    tables.add(caseSensitive ? table : table.toLowerCase());
                 }
-                tables.add(caseSensitive ? table : table.toLowerCase());
             }
             return tables;
         }

--- a/src/main/java/org/pjdbc/sql/SqlPatterns.java
+++ b/src/main/java/org/pjdbc/sql/SqlPatterns.java
@@ -1,0 +1,31 @@
+package org.pjdbc.sql;
+
+import java.util.regex.Pattern;
+
+/**
+ * Centralized SQL patterns for security-hardened parsing.
+ */
+public class SqlPatterns {
+
+    /**
+     * Regex that matches SQL comments (both block and line comments).
+     */
+    public static final String SQL_COMMENT = "(?:/\\*[\\s\\S]*?\\*/|--.*)";
+
+    /**
+     * Regex that matches optional whitespace and comments.
+     */
+    public static final String SQL_SEP_OPT = "(?:\\s|" + SQL_COMMENT + ")*";
+
+    /**
+     * Regex that matches mandatory whitespace and/or comments.
+     */
+    public static final String SQL_SEP = "(?:\\s|" + SQL_COMMENT + ")+";
+
+    /**
+     * Regex for a standard SQL identifier (unquoted).
+     */
+    public static final String IDENTIFIER_REGEX = "[a-zA-Z_][a-zA-Z0-9_]*";
+
+    private SqlPatterns() {}
+}

--- a/src/test/java/org/pjdbc/conformance/ParameterDefaultConformanceTest.java
+++ b/src/test/java/org/pjdbc/conformance/ParameterDefaultConformanceTest.java
@@ -130,9 +130,9 @@ public class ParameterDefaultConformanceTest extends DriverConformanceTest {
             for (DriverCapability.Parameter param : driver.parameters()) {
                 assertNotNull(param.name(), "Parameter name should not be null in " + driver.name());
                 assertFalse(param.name().isEmpty(), "Parameter name should not be empty in " + driver.name());
-                assertTrue(param.name().matches("[a-zA-Z][a-zA-Z0-9_]*"),
+                assertTrue(param.name().matches("[a-zA-Z][a-zA-Z0-9_]*(\\.\\*)?"),
                     "Parameter name '" + param.name() + "' in " + driver.name() +
-                    " should be a valid identifier");
+                    " should be a valid identifier or wildcard pattern");
             }
         }
     }

--- a/src/test/java/org/pjdbc/drivers/SecurityBypassTest.java
+++ b/src/test/java/org/pjdbc/drivers/SecurityBypassTest.java
@@ -1,0 +1,76 @@
+package org.pjdbc.drivers;
+
+import static org.junit.Assert.fail;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class SecurityBypassTest {
+
+    @BeforeClass
+    public static void loadDriver() throws ClassNotFoundException {
+        Class.forName("org.pjdbc.drivers.ReadonlyDriver");
+        Class.forName("org.pjdbc.drivers.SchemaValidationDriver");
+        Class.forName("org.pjdbc.drivers.DataMaskingDriver");
+    }
+
+    @Test
+    public void testReadonlyCommentBypass() throws SQLException {
+        String url = "jdbc:readonly:jdbc:h2:mem:readonly_bypass";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                // This should be blocked, but if it's bypassed it will try to execute
+                // We use a syntax that is valid in H2 but starts with a comment
+                stmt.execute("/**/ CREATE TABLE bypass (id INT)");
+                // If it reached here, it bypassed the check (though CREATE might fail if H2 doesn't like it at the start,
+                // but the point is it passed ReadonlyDriver)
+            }
+        } catch (SQLException e) {
+            if (e.getMessage().contains("ReadonlyDriver")) {
+                // Correctly blocked
+                return;
+            }
+            // Other SQL error
+        }
+        fail("ReadonlyDriver bypass: statement with leading comment was not blocked");
+    }
+
+    @Test
+    public void testReadonlyCteBypass() throws SQLException {
+        String url = "jdbc:readonly:jdbc:h2:mem:readonly_cte";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute("WITH t AS (INSERT INTO some_table VALUES (1)) SELECT 1");
+            }
+        } catch (SQLException e) {
+            if (e.getMessage().contains("ReadonlyDriver")) {
+                return;
+            }
+        }
+        fail("ReadonlyDriver bypass: WITH statement with DML was not blocked");
+    }
+
+    @Test
+    public void testSchemaValidationCommaBypass() throws SQLException {
+        String url = "jdbc:schema[allowedTables=t1]:jdbc:h2:mem:schema_bypass";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                // Create t1 and t2 first in a non-proxy connection
+                try (Connection raw = DriverManager.getConnection("jdbc:h2:mem:schema_bypass")) {
+                    raw.createStatement().execute("CREATE TABLE t1 (id INT)");
+                    raw.createStatement().execute("CREATE TABLE t2 (id INT)");
+                }
+                // Should only allow t1. But it might allow t2 if comma-separated.
+                stmt.executeQuery("SELECT * FROM t1, t2");
+            }
+        } catch (SQLException e) {
+            if (e.getMessage().contains("SchemaValidationDriver")) {
+                return;
+            }
+        }
+        fail("SchemaValidationDriver bypass: comma-separated table was not blocked");
+    }
+}


### PR DESCRIPTION
### 🛡️ Sentinel: [security improvement] Harden SQL regex parsing against comment and CTE bypasses

🚨 **Severity**: MEDIUM (Security Hardening)

💡 **Vulnerability**: SQL security drivers (`ReadonlyDriver`, `SchemaValidationDriver`) that rely on regex-based SQL inspection were vulnerable to various bypass vectors:
1. **Comment-based bypass**: Leading SQL comments (e.g., `/**/ INSERT...`) could bypass `^\\s*` anchored checks.
2. **CTE-based bypass**: DML operations initiated via Common Table Expressions (e.g., `WITH x AS (DELETE...) SELECT...`) were not detected by `ReadonlyDriver`.
3. **Identifier list bypass**: `SchemaValidationDriver` only validated the first table in comma-separated lists (e.g., `FROM t1, t2`), potentially allowing unauthorized access to subsequent tables.

🎯 **Impact**: Malicious actors or accidental operations could bypass established security controls (readonly enforcement or schema validation) to perform unauthorized modifications or access sensitive data.

🔧 **Fix**:
- Created `org.pjdbc.sql.SqlPatterns` to provide centralized, robust regex components for SQL comments and separators.
- Updated `ReadonlyDriver` patterns to use `SQL_SEP_OPT` for leading comment protection and added the `WITH` keyword to the DML blocklist.
- Refactored `SchemaValidationDriver` table extraction to use `SQL_SEP` for keyword boundaries and correctly process all tables in comma-separated identifier lists, while ignoring embedded comments.
- Adjusted `ParameterDefaultConformanceTest` to support wildcard parameter names (e.g., `rename.*`) used by some drivers.

✅ **Verification**:
- Created `src/test/java/org/pjdbc/drivers/SecurityBypassTest.java` which explicitly reproduces and verifies the fixes for leading comments, CTEs, and comma-separated tables.
- Ran full fast test suite (`mvn test -Pfast`) and ensured all 937 tests pass.


---
*PR created automatically by Jules for task [2901950809224878381](https://jules.google.com/task/2901950809224878381) started by @davidaventimiglia-professional*