### PR TITLE
🛡️ Sentinel: Harden SQL parsing against comment bypasses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-21 - Security bypass via SQL comments
+**Vulnerability:** Regex-based SQL security filters (like ReadonlyDriver and SchemaValidationDriver) could be bypassed by using SQL comments (/* ... */ or -- ...) as separators instead of whitespace. For example, "/* bypass */ DELETE FROM table" would not match a pattern anchored with "^\\s*DELETE".
+**Learning:** Naive regexes that assume whitespace as the only possible separator between SQL keywords and identifiers are inherently vulnerable to comment-based bypasses.
+**Prevention:** Use a centralized, comment-aware separator regex (e.g., SqlPatterns.SQL_SEP) for all security-critical SQL parsing and transformation.

--- a/src/main/java/org/pjdbc/drivers/FederatingDriver.java
+++ b/src/main/java/org/pjdbc/drivers/FederatingDriver.java
@@ -12,6 +12,7 @@ import org.pjdbc.annotations.DriverParameter;
 import org.pjdbc.annotations.DriverParameter.ParameterType;
 import org.pjdbc.annotations.DriverSideEffects;
 import org.pjdbc.sql.*;
+import org.pjdbc.sql.SqlPatterns;
 import static org.pjdbc.sql.PjdbcListeners.fireFederatedQuery;
 
 /**
@@ -102,7 +103,7 @@ public class FederatingDriver extends AbstractDriver {
      * Matches: FROM table, JOIN table, INTO table, UPDATE table, TABLE table (for TRUNCATE)
      */
     private static final java.util.regex.Pattern TABLE_PATTERN = java.util.regex.Pattern.compile(
-        "\\b(?:FROM|JOIN|INTO|UPDATE|TABLE|TRUNCATE)\\s+([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)?)",
+        "\\b(?:FROM|JOIN|INTO|UPDATE|TABLE|TRUNCATE)" + SqlPatterns.SQL_SEP + "([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)?)",
         java.util.regex.Pattern.CASE_INSENSITIVE
     );
 

--- a/src/main/java/org/pjdbc/drivers/ReadonlyDriver.java
+++ b/src/main/java/org/pjdbc/drivers/ReadonlyDriver.java
@@ -20,6 +20,7 @@ import org.pjdbc.sql.AbstractPreparedStatement;
 import org.pjdbc.sql.AbstractProxyDriver;
 import org.pjdbc.sql.AbstractStatement;
 import org.pjdbc.sql.JdbcUrlParser;
+import org.pjdbc.sql.SqlPatterns;
 
 /**
  * ReadonlyDriver enforces read-only database access by blocking write operations.
@@ -56,19 +57,19 @@ public class ReadonlyDriver extends AbstractProxyDriver {
 
     // Pattern to detect DML write operations
     private static final Pattern DML_PATTERN = Pattern.compile(
-        "^\\s*(INSERT|UPDATE|DELETE|MERGE|UPSERT|REPLACE|TRUNCATE)\\b",
+        "^" + SqlPatterns.SQL_SEP_OPT + "(INSERT|UPDATE|DELETE|MERGE|UPSERT|REPLACE|TRUNCATE)\\b",
         Pattern.CASE_INSENSITIVE
     );
 
     // Pattern to detect DDL operations
     private static final Pattern DDL_PATTERN = Pattern.compile(
-        "^\\s*(CREATE|ALTER|DROP|RENAME)\\b",
+        "^" + SqlPatterns.SQL_SEP_OPT + "(CREATE|ALTER|DROP|RENAME)\\b",
         Pattern.CASE_INSENSITIVE
     );
 
     // Pattern to detect DCL operations
     private static final Pattern DCL_PATTERN = Pattern.compile(
-        "^\\s*(GRANT|REVOKE)\\b",
+        "^" + SqlPatterns.SQL_SEP_OPT + "(GRANT|REVOKE)\\b",
         Pattern.CASE_INSENSITIVE
     );
 

--- a/src/main/java/org/pjdbc/drivers/SchemaValidationDriver.java
+++ b/src/main/java/org/pjdbc/drivers/SchemaValidationDriver.java
@@ -27,6 +27,7 @@ import org.pjdbc.sql.AbstractPreparedStatement;
 import org.pjdbc.sql.AbstractProxyDriver;
 import org.pjdbc.sql.AbstractStatement;
 import org.pjdbc.sql.JdbcUrlParser;
+import org.pjdbc.sql.SqlPatterns;
 
 /**
  * SchemaValidationDriver validates SQL statements against a defined schema.
@@ -79,25 +80,25 @@ public class SchemaValidationDriver extends AbstractProxyDriver {
     // Pattern to extract table names from SQL
     // Matches: FROM table, JOIN table, INTO table, UPDATE table, TABLE table (for TRUNCATE)
     private static final Pattern TABLE_PATTERN = Pattern.compile(
-        "\\b(?:FROM|JOIN|INTO|UPDATE|TABLE|TRUNCATE)\\s+([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)?)",
+        "\\b(?:FROM|JOIN|INTO|UPDATE|TABLE|TRUNCATE)" + SqlPatterns.SQL_SEP + "([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)?)",
         Pattern.CASE_INSENSITIVE
     );
 
     // Pattern to extract column names from SELECT
     private static final Pattern SELECT_COLUMNS_PATTERN = Pattern.compile(
-        "\\bSELECT\\s+(.+?)\\s+FROM\\b",
+        "\\bSELECT" + SqlPatterns.SQL_SEP + "(.+?)" + SqlPatterns.SQL_SEP + "FROM\\b",
         Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to extract columns from INSERT
     private static final Pattern INSERT_COLUMNS_PATTERN = Pattern.compile(
-        "\\bINSERT\\s+INTO\\s+[a-zA-Z_][a-zA-Z0-9_.]*\\s*\\(([^)]+)\\)",
+        "\\bINSERT" + SqlPatterns.SQL_SEP + "INTO" + SqlPatterns.SQL_SEP + "[a-zA-Z_][a-zA-Z0-9_.]*" + SqlPatterns.SQL_SEP_OPT + "\\(([^)]+)\\)",
         Pattern.CASE_INSENSITIVE
     );
 
     // Pattern to extract columns from UPDATE SET
     private static final Pattern UPDATE_COLUMNS_PATTERN = Pattern.compile(
-        "\\bSET\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
+        "\\bSET" + SqlPatterns.SQL_SEP + "([a-zA-Z_][a-zA-Z0-9_]*)",
         Pattern.CASE_INSENSITIVE
     );
 

--- a/src/main/java/org/pjdbc/sql/SchemaTransformer.java
+++ b/src/main/java/org/pjdbc/sql/SchemaTransformer.java
@@ -42,9 +42,9 @@ public class SchemaTransformer extends AbstractJdbcTransformer {
     // - INTO tablename
     // - UPDATE tablename
     // - TABLE tablename (for TRUNCATE TABLE, etc.)
-    // Captures: keyword, optional whitespace, table name (not already qualified)
+    // Captures: keyword, separator, table name (not already qualified)
     private static final Pattern TABLE_PATTERN = Pattern.compile(
-        "\\b(FROM|JOIN|INTO|UPDATE|TABLE)\\s+(?!\\w+\\.)([a-zA-Z_][a-zA-Z0-9_]*)",
+        "\\b(FROM|JOIN|INTO|UPDATE|TABLE)(" + SqlPatterns.SQL_SEP + ")(?!\\w+\\.)([a-zA-Z_][a-zA-Z0-9_]*)",
         Pattern.CASE_INSENSITIVE
     );
 
@@ -71,9 +71,10 @@ public class SchemaTransformer extends AbstractJdbcTransformer {
 
         while (matcher.find()) {
             String keyword = matcher.group(1);
-            String tableName = matcher.group(2);
-            // Replace with: keyword + space + schema.tablename
-            matcher.appendReplacement(result, keyword + " " + schemaPrefix + tableName);
+            String separator = matcher.group(2);
+            String tableName = matcher.group(3);
+            // Replace with: keyword + separator + schema.tablename
+            matcher.appendReplacement(result, Matcher.quoteReplacement(keyword + separator + schemaPrefix + tableName));
         }
         matcher.appendTail(result);
 

--- a/src/main/java/org/pjdbc/sql/SqlPatterns.java
+++ b/src/main/java/org/pjdbc/sql/SqlPatterns.java
@@ -1,0 +1,16 @@
+package org.pjdbc.sql;
+
+/**
+ * Shared SQL regex patterns for consistent comment-aware parsing.
+ */
+public class SqlPatterns {
+    /**
+     * Matches one or more SQL separators: whitespace, block comments, or line comments.
+     */
+    public static final String SQL_SEP = "(?:\\s+|/\\*[\\s\\S]*?\\*/|--.*(?:\\r?\\n|$))+";
+
+    /**
+     * Matches zero or more SQL separators: whitespace, block comments, or line comments.
+     */
+    public static final String SQL_SEP_OPT = "(?:\\s+|/\\*[\\s\\S]*?\\*/|--.*(?:\\r?\\n|$))*";
+}

--- a/src/main/java/org/pjdbc/sql/WhereTransformer.java
+++ b/src/main/java/org/pjdbc/sql/WhereTransformer.java
@@ -49,13 +49,13 @@ public class WhereTransformer extends AbstractJdbcTransformer {
     // Pattern to find insertion point for new WHERE clause
     // Matches: GROUP BY, HAVING, ORDER BY, LIMIT, OFFSET, UNION, INTERSECT, EXCEPT, or end
     private static final Pattern WHERE_INSERTION_POINT = Pattern.compile(
-        "\\s+(GROUP\\s+BY|HAVING|ORDER\\s+BY|LIMIT|OFFSET|UNION|INTERSECT|EXCEPT|FOR\\s+UPDATE|FOR\\s+SHARE)\\b",
+        "(" + SqlPatterns.SQL_SEP + ")(GROUP" + SqlPatterns.SQL_SEP + "BY|HAVING|ORDER" + SqlPatterns.SQL_SEP + "BY|LIMIT|OFFSET|UNION|INTERSECT|EXCEPT|FOR" + SqlPatterns.SQL_SEP + "UPDATE|FOR" + SqlPatterns.SQL_SEP + "SHARE)\\b",
         Pattern.CASE_INSENSITIVE
     );
 
     // Pattern to detect SELECT/UPDATE/DELETE statements (not INSERT)
     private static final Pattern MODIFIABLE_STATEMENT = Pattern.compile(
-        "^\\s*(SELECT|UPDATE|DELETE)\\b",
+        "^" + SqlPatterns.SQL_SEP_OPT + "(SELECT|UPDATE|DELETE)\\b",
         Pattern.CASE_INSENSITIVE
     );
 
@@ -63,7 +63,7 @@ public class WhereTransformer extends AbstractJdbcTransformer {
     // We need to find WHERE that's not inside parentheses (subquery)
     // This is a simplification - we find WHERE and append at the insertion point
     private static final Pattern WHERE_CLAUSE_END = Pattern.compile(
-        "\\bWHERE\\b(.+?)(?=(GROUP\\s+BY|HAVING|ORDER\\s+BY|LIMIT|OFFSET|UNION|INTERSECT|EXCEPT|FOR\\s+UPDATE|FOR\\s+SHARE|$))",
+        "\\bWHERE\\b(.+?)(?=(" + SqlPatterns.SQL_SEP + "(?:GROUP" + SqlPatterns.SQL_SEP + "BY|HAVING|ORDER" + SqlPatterns.SQL_SEP + "BY|LIMIT|OFFSET|UNION|INTERSECT|EXCEPT|FOR" + SqlPatterns.SQL_SEP + "UPDATE|FOR" + SqlPatterns.SQL_SEP + "SHARE)|$))",
         Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
@@ -128,8 +128,9 @@ public class WhereTransformer extends AbstractJdbcTransformer {
         Matcher matcher = WHERE_INSERTION_POINT.matcher(sql);
         if (matcher.find()) {
             // Insert WHERE before GROUP BY, ORDER BY, etc.
-            int insertPos = matcher.start();
-            return sql.substring(0, insertPos) + " WHERE " + condition + sql.substring(insertPos);
+            String separator = matcher.group(1);
+            String following = matcher.group(2);
+            return matcher.replaceFirst(Matcher.quoteReplacement(" WHERE " + condition + separator + following));
         }
 
         // No insertion point found - append at end

--- a/src/test/java/org/pjdbc/conformance/ParameterDefaultConformanceTest.java
+++ b/src/test/java/org/pjdbc/conformance/ParameterDefaultConformanceTest.java
@@ -130,7 +130,7 @@ public class ParameterDefaultConformanceTest extends DriverConformanceTest {
             for (DriverCapability.Parameter param : driver.parameters()) {
                 assertNotNull(param.name(), "Parameter name should not be null in " + driver.name());
                 assertFalse(param.name().isEmpty(), "Parameter name should not be empty in " + driver.name());
-                assertTrue(param.name().matches("[a-zA-Z][a-zA-Z0-9_]*"),
+                assertTrue(param.name().matches("[a-zA-Z][a-zA-Z0-9_]*(\\.\\*)?"),
                     "Parameter name '" + param.name() + "' in " + driver.name() +
                     " should be a valid identifier");
             }

--- a/src/test/java/org/pjdbc/drivers/SecurityBypassTest.java
+++ b/src/test/java/org/pjdbc/drivers/SecurityBypassTest.java
@@ -1,0 +1,65 @@
+package org.pjdbc.drivers;
+
+import static org.junit.Assert.fail;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.junit.Test;
+
+public class SecurityBypassTest {
+    @Test
+    public void testReadonlyCommentBypass() throws SQLException {
+        // Allow DDL so we can setup the table, but block DML
+        String url = "jdbc:readonly[allowDDL=true]:jdbc:h2:mem:test_readonly_bypass;DB_CLOSE_DELAY=-1";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute("CREATE TABLE test (id INT)");
+
+                // Blocked DML with comments
+                assertBlocked(stmt, "/* comment */ INSERT INTO test VALUES (1)");
+                assertBlocked(stmt, "-- line comment\nINSERT INTO test VALUES (1)");
+                assertBlocked(stmt, "  \n  /* comment */  DELETE FROM test");
+            }
+        }
+    }
+
+    @Test
+    public void testSchemaValidationCommentBypass() throws SQLException {
+        // Setup tables using direct H2 connection to bypass schema validation during setup
+        try (Connection setupConn = DriverManager.getConnection("jdbc:h2:mem:test_schema_bypass;DB_CLOSE_DELAY=-1")) {
+            try (Statement stmt = setupConn.createStatement()) {
+                stmt.execute("CREATE TABLE users (id INT)");
+                stmt.execute("CREATE TABLE secrets (data VARCHAR)");
+            }
+        }
+
+        // Whitelist 'users', block 'secrets'
+        String url = "jdbc:schema[allowedTables=users,mode=whitelist]:jdbc:h2:mem:test_schema_bypass;DB_CLOSE_DELAY=-1";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                // Should be allowed
+                stmt.execute("SELECT * FROM /* comment */ users");
+
+                // Should be blocked even with comments as separators
+                assertBlocked(stmt, "SELECT * FROM /* comment */ secrets");
+                assertBlocked(stmt, "SELECT * FROM -- comment\nsecrets");
+                assertBlocked(stmt, "SELECT * FROM\n/* comment */\nsecrets");
+
+                // Blocked in other clauses
+                assertBlocked(stmt, "INSERT INTO /* comment */ secrets VALUES ('data')");
+                assertBlocked(stmt, "UPDATE /* comment */ secrets SET data='new'");
+                assertBlocked(stmt, "DELETE FROM /* comment */ secrets");
+            }
+        }
+    }
+
+    private void assertBlocked(Statement stmt, String sql) {
+        try {
+            stmt.execute(sql);
+            fail("Should have blocked: " + sql);
+        } catch (SQLException e) {
+            // Expected
+        }
+    }
+}

--- a/src/test/java/org/pjdbc/sql/TransformerCommentTest.java
+++ b/src/test/java/org/pjdbc/sql/TransformerCommentTest.java
@@ -1,0 +1,48 @@
+package org.pjdbc.sql;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import java.sql.SQLException;
+import org.junit.Test;
+
+public class TransformerCommentTest {
+    @Test
+    public void testSchemaTransformerPreservesComments() throws SQLException {
+        SchemaTransformer transformer = new SchemaTransformer("tenant1");
+
+        // Block comment as separator
+        String sql1 = "SELECT * FROM /* comment */ users";
+        String transformed1 = transformer.transformSql(sql1);
+        assertEquals("SELECT * FROM /* comment */ tenant1.users", transformed1);
+
+        // Line comment as separator
+        String sql2 = "SELECT * FROM -- comment\nusers";
+        String transformed2 = transformer.transformSql(sql2);
+        assertEquals("SELECT * FROM -- comment\ntenant1.users", transformed2);
+    }
+
+    @Test
+    public void testWhereTransformerPreservesComments() throws SQLException {
+        WhereTransformer transformer = new WhereTransformer("tenant_id=123");
+
+        // Block comment before insertion point
+        String sql1 = "SELECT * FROM users /* comment */ ORDER BY name";
+        String transformed1 = transformer.transformSql(sql1);
+        assertEquals("SELECT * FROM users WHERE tenant_id=123 /* comment */ ORDER BY name", transformed1);
+
+        // Multiple separators and comments
+        String sql2 = "SELECT * FROM users \n /* comment */ \n ORDER BY name";
+        String transformed2 = transformer.transformSql(sql2);
+        assertEquals("SELECT * FROM users WHERE tenant_id=123 \n /* comment */ \n ORDER BY name", transformed2);
+    }
+
+    @Test
+    public void testWhereTransformerLeadingComment() throws SQLException {
+        WhereTransformer transformer = new WhereTransformer("tenant_id=123");
+
+        String sql = "/* leading */ SELECT * FROM users";
+        String transformed = transformer.transformSql(sql);
+        assertTrue(transformed.startsWith("/* leading */"));
+        assertTrue(transformed.contains("WHERE tenant_id=123"));
+    }
+}


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Harden SQL parsing against comment bypasses

### 🚨 Severity: HIGH

### 💡 Vulnerability:
Regex-based SQL security filters (like ReadonlyDriver and SchemaValidationDriver) could be bypassed by using SQL comments (/* ... */ or -- ...) as separators instead of whitespace. For example, "/* bypass */ DELETE FROM table" would not match a pattern anchored with "^\\s*DELETE", and "SELECT * FROM /* comment */ secret_table" would bypass table name detection using naive whitespace boundaries.

### 🎯 Impact:
An attacker could bypass read-only restrictions or schema validation rules by carefully placing comments in their SQL statements, potentially leading to unauthorized data modification or access to sensitive tables that were supposed to be blocked.

### 🔧 Fix:
1.  **Centralized Parsing Logic**: Introduced `org.pjdbc.sql.SqlPatterns` to define `SQL_SEP` and `SQL_SEP_OPT` regexes that correctly handle whitespace and both block/line SQL comments.
2.  **Driver Hardening**: Updated `ReadonlyDriver`, `SchemaValidationDriver`, and `FederatingDriver` to use these centralized patterns, ensuring that leading comments or comments between keywords/identifiers do not cause bypasses.
3.  **Transformer Improvement**: Updated `WhereTransformer` and `SchemaTransformer` to be comment-aware and to preserve original separators (including comments) when rewriting SQL. Used `Matcher.quoteReplacement()` to prevent potential replacement-string injection.
4.  **Conformance**: Updated `ParameterDefaultConformanceTest` to support the `rename.*` wildcard parameter pattern used by `FilterDriver`.

### ✅ Verification:
- Created `src/test/java/org/pjdbc/drivers/SecurityBypassTest.java` verifying that Readonly and Schema drivers now correctly block statements with leading or intermediate comments.
- Created `src/test/java/org/pjdbc/sql/TransformerCommentTest.java` verifying that transformers preserve comments during transformation.
- Ran the full test suite (`mvn test -Pfast`), with all 939 tests passing.
- Verified that the project compiles and builds successfully.
- Recorded the security learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [15588834155135336428](https://jules.google.com/task/15588834155135336428) started by @davidaventimiglia-professional*