### PR TITLE
🛡️ Sentinel: [HIGH] Fix data masking bypasses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-26 - Data Masking Bypass via Aliasing and LOBs
+**Vulnerability:** Data masking in `DataMaskingDriver` could be bypassed using SQL column aliasing (e.g., `SELECT secret AS alias`) when using label-based getters, or by using LOB/complex type getters (e.g., `getBlob`, `getObject(int, Class)`) which were not overridden.
+**Learning:** Security-focused `ResultSet` proxies must resolve column labels to indices using `findColumn()` and delegate to index-based logic to ensure consistent security state application regardless of SQL-level aliasing. Furthermore, any method in a delegated interface that returns data must be explicitly handled (either masked or blocked) to prevent "fail-open" bypasses.
+**Prevention:** In security proxies, refactor all label-based interface methods to delegate to index-based ones. Perform a complete audit of the delegated interface (e.g., `ResultSet`) to ensure no data-retrieval methods are left with default pass-through behavior.

--- a/src/main/java/org/pjdbc/drivers/DataMaskingDriver.java
+++ b/src/main/java/org/pjdbc/drivers/DataMaskingDriver.java
@@ -475,11 +475,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public String getString(String columnLabel) throws SQLException {
-            String value = super.getString(columnLabel);
-            if (config.shouldMask(columnLabel) && value != null) {
-                return config.maskValue(value);
-            }
-            return value;
+            return getString(findColumn(columnLabel));
         }
 
         @Override
@@ -493,11 +489,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public String getNString(String columnLabel) throws SQLException {
-            String value = super.getNString(columnLabel);
-            if (config.shouldMask(columnLabel) && value != null) {
-                return config.maskValue(value);
-            }
-            return value;
+            return getNString(findColumn(columnLabel));
         }
 
         // === OBJECT METHODS ===
@@ -518,16 +510,38 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public Object getObject(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) {
-                Object value = super.getObject(columnLabel);
-                if (value == null) return null;
-                if (value instanceof String s) {
-                    return config.maskValue(s);
+            return getObject(findColumn(columnLabel));
+        }
+
+        @Override
+        public <T> T getObject(int columnIndex, Class<T> type) throws SQLException {
+            if (shouldMaskColumn(columnIndex)) {
+                if (type == String.class) {
+                    @SuppressWarnings("unchecked")
+                    T val = (T) config.maskValue(super.getString(columnIndex));
+                    return val;
                 }
-                // Non-string type in masked column - throw to prevent data leak
-                throwMaskedColumnException(columnLabel, "getObject");
+                throwMaskedColumnException(String.valueOf(columnIndex), "getObject");
             }
-            return super.getObject(columnLabel);
+            return super.getObject(columnIndex, type);
+        }
+
+        @Override
+        public <T> T getObject(String columnLabel, Class<T> type) throws SQLException {
+            return getObject(findColumn(columnLabel), type);
+        }
+
+        @Override
+        public Object getObject(int columnIndex, java.util.Map<String, Class<?>> map) throws SQLException {
+            if (shouldMaskColumn(columnIndex)) {
+                throwMaskedColumnException(String.valueOf(columnIndex), "getObject");
+            }
+            return super.getObject(columnIndex, map);
+        }
+
+        @Override
+        public Object getObject(String columnLabel, java.util.Map<String, Class<?>> map) throws SQLException {
+            return getObject(findColumn(columnLabel), map);
         }
 
         // === NUMERIC METHODS - throw SQLException for masked columns ===
@@ -540,8 +554,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public byte getByte(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getByte");
-            return super.getByte(columnLabel);
+            return getByte(findColumn(columnLabel));
         }
 
         @Override
@@ -552,8 +565,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public short getShort(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getShort");
-            return super.getShort(columnLabel);
+            return getShort(findColumn(columnLabel));
         }
 
         @Override
@@ -564,8 +576,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public int getInt(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getInt");
-            return super.getInt(columnLabel);
+            return getInt(findColumn(columnLabel));
         }
 
         @Override
@@ -576,8 +587,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public long getLong(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getLong");
-            return super.getLong(columnLabel);
+            return getLong(findColumn(columnLabel));
         }
 
         @Override
@@ -588,8 +598,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public float getFloat(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getFloat");
-            return super.getFloat(columnLabel);
+            return getFloat(findColumn(columnLabel));
         }
 
         @Override
@@ -600,8 +609,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public double getDouble(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getDouble");
-            return super.getDouble(columnLabel);
+            return getDouble(findColumn(columnLabel));
         }
 
         @Override
@@ -612,8 +620,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public java.math.BigDecimal getBigDecimal(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getBigDecimal");
-            return super.getBigDecimal(columnLabel);
+            return getBigDecimal(findColumn(columnLabel));
         }
 
         @Override
@@ -626,8 +633,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
         @Override
         @SuppressWarnings("deprecation")
         public java.math.BigDecimal getBigDecimal(String columnLabel, int scale) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getBigDecimal");
-            return super.getBigDecimal(columnLabel, scale);
+            return getBigDecimal(findColumn(columnLabel), scale);
         }
 
         // === BYTES - return masked string as bytes ===
@@ -644,12 +650,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public byte[] getBytes(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) {
-                String value = super.getString(columnLabel);
-                if (value == null) return null;
-                return config.maskValue(value).getBytes(java.nio.charset.StandardCharsets.UTF_8);
-            }
-            return super.getBytes(columnLabel);
+            return getBytes(findColumn(columnLabel));
         }
 
         // === BOOLEAN - throw SQLException for masked columns ===
@@ -662,8 +663,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public boolean getBoolean(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getBoolean");
-            return super.getBoolean(columnLabel);
+            return getBoolean(findColumn(columnLabel));
         }
 
         // === DATE/TIME METHODS - throw SQLException for masked columns ===
@@ -676,8 +676,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public java.sql.Date getDate(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getDate");
-            return super.getDate(columnLabel);
+            return getDate(findColumn(columnLabel));
         }
 
         @Override
@@ -688,8 +687,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public java.sql.Date getDate(String columnLabel, java.util.Calendar cal) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getDate");
-            return super.getDate(columnLabel, cal);
+            return getDate(findColumn(columnLabel), cal);
         }
 
         @Override
@@ -700,8 +698,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public java.sql.Time getTime(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getTime");
-            return super.getTime(columnLabel);
+            return getTime(findColumn(columnLabel));
         }
 
         @Override
@@ -712,8 +709,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public java.sql.Time getTime(String columnLabel, java.util.Calendar cal) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getTime");
-            return super.getTime(columnLabel, cal);
+            return getTime(findColumn(columnLabel), cal);
         }
 
         @Override
@@ -724,8 +720,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public java.sql.Timestamp getTimestamp(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getTimestamp");
-            return super.getTimestamp(columnLabel);
+            return getTimestamp(findColumn(columnLabel));
         }
 
         @Override
@@ -736,8 +731,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public java.sql.Timestamp getTimestamp(String columnLabel, java.util.Calendar cal) throws SQLException {
-            if (config.shouldMask(columnLabel)) throwMaskedColumnException(columnLabel, "getTimestamp");
-            return super.getTimestamp(columnLabel, cal);
+            return getTimestamp(findColumn(columnLabel), cal);
         }
 
         // === CHARACTER STREAMS - return stream of masked content ===
@@ -754,12 +748,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public java.io.Reader getCharacterStream(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) {
-                String value = super.getString(columnLabel);
-                if (value == null) return null;
-                return new java.io.StringReader(config.maskValue(value));
-            }
-            return super.getCharacterStream(columnLabel);
+            return getCharacterStream(findColumn(columnLabel));
         }
 
         @Override
@@ -774,12 +763,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public java.io.Reader getNCharacterStream(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) {
-                String value = super.getNString(columnLabel);
-                if (value == null) return null;
-                return new java.io.StringReader(config.maskValue(value));
-            }
-            return super.getNCharacterStream(columnLabel);
+            return getNCharacterStream(findColumn(columnLabel));
         }
 
         // === BINARY STREAMS - return stream of masked bytes ===
@@ -797,13 +781,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public java.io.InputStream getAsciiStream(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) {
-                String value = super.getString(columnLabel);
-                if (value == null) return null;
-                byte[] maskedBytes = config.maskValue(value).getBytes(java.nio.charset.StandardCharsets.US_ASCII);
-                return new java.io.ByteArrayInputStream(maskedBytes);
-            }
-            return super.getAsciiStream(columnLabel);
+            return getAsciiStream(findColumn(columnLabel));
         }
 
         @Override
@@ -819,13 +797,7 @@ public class DataMaskingDriver extends AbstractProxyDriver {
 
         @Override
         public java.io.InputStream getBinaryStream(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) {
-                String value = super.getString(columnLabel);
-                if (value == null) return null;
-                byte[] maskedBytes = config.maskValue(value).getBytes(java.nio.charset.StandardCharsets.UTF_8);
-                return new java.io.ByteArrayInputStream(maskedBytes);
-            }
-            return super.getBinaryStream(columnLabel);
+            return getBinaryStream(findColumn(columnLabel));
         }
 
         @Override
@@ -843,13 +815,97 @@ public class DataMaskingDriver extends AbstractProxyDriver {
         @Override
         @SuppressWarnings("deprecation")
         public java.io.InputStream getUnicodeStream(String columnLabel) throws SQLException {
-            if (config.shouldMask(columnLabel)) {
-                String value = super.getString(columnLabel);
-                if (value == null) return null;
-                byte[] maskedBytes = config.maskValue(value).getBytes(java.nio.charset.StandardCharsets.UTF_16);
-                return new java.io.ByteArrayInputStream(maskedBytes);
-            }
-            return super.getUnicodeStream(columnLabel);
+            return getUnicodeStream(findColumn(columnLabel));
+        }
+
+        // === LOB AND COMPLEX TYPES - throw SQLException for masked columns ===
+
+        @Override
+        public java.sql.Blob getBlob(int columnIndex) throws SQLException {
+            if (shouldMaskColumn(columnIndex)) throwMaskedColumnException(String.valueOf(columnIndex), "getBlob");
+            return super.getBlob(columnIndex);
+        }
+
+        @Override
+        public java.sql.Blob getBlob(String columnLabel) throws SQLException {
+            return getBlob(findColumn(columnLabel));
+        }
+
+        @Override
+        public java.sql.Clob getClob(int columnIndex) throws SQLException {
+            if (shouldMaskColumn(columnIndex)) throwMaskedColumnException(String.valueOf(columnIndex), "getClob");
+            return super.getClob(columnIndex);
+        }
+
+        @Override
+        public java.sql.Clob getClob(String columnLabel) throws SQLException {
+            return getClob(findColumn(columnLabel));
+        }
+
+        @Override
+        public java.sql.NClob getNClob(int columnIndex) throws SQLException {
+            if (shouldMaskColumn(columnIndex)) throwMaskedColumnException(String.valueOf(columnIndex), "getNClob");
+            return super.getNClob(columnIndex);
+        }
+
+        @Override
+        public java.sql.NClob getNClob(String columnLabel) throws SQLException {
+            return getNClob(findColumn(columnLabel));
+        }
+
+        @Override
+        public java.sql.Array getArray(int columnIndex) throws SQLException {
+            if (shouldMaskColumn(columnIndex)) throwMaskedColumnException(String.valueOf(columnIndex), "getArray");
+            return super.getArray(columnIndex);
+        }
+
+        @Override
+        public java.sql.Array getArray(String columnLabel) throws SQLException {
+            return getArray(findColumn(columnLabel));
+        }
+
+        @Override
+        public java.sql.Ref getRef(int columnIndex) throws SQLException {
+            if (shouldMaskColumn(columnIndex)) throwMaskedColumnException(String.valueOf(columnIndex), "getRef");
+            return super.getRef(columnIndex);
+        }
+
+        @Override
+        public java.sql.Ref getRef(String columnLabel) throws SQLException {
+            return getRef(findColumn(columnLabel));
+        }
+
+        @Override
+        public java.sql.RowId getRowId(int columnIndex) throws SQLException {
+            if (shouldMaskColumn(columnIndex)) throwMaskedColumnException(String.valueOf(columnIndex), "getRowId");
+            return super.getRowId(columnIndex);
+        }
+
+        @Override
+        public java.sql.RowId getRowId(String columnLabel) throws SQLException {
+            return getRowId(findColumn(columnLabel));
+        }
+
+        @Override
+        public java.sql.SQLXML getSQLXML(int columnIndex) throws SQLException {
+            if (shouldMaskColumn(columnIndex)) throwMaskedColumnException(String.valueOf(columnIndex), "getSQLXML");
+            return super.getSQLXML(columnIndex);
+        }
+
+        @Override
+        public java.sql.SQLXML getSQLXML(String columnLabel) throws SQLException {
+            return getSQLXML(findColumn(columnLabel));
+        }
+
+        @Override
+        public java.net.URL getURL(int columnIndex) throws SQLException {
+            if (shouldMaskColumn(columnIndex)) throwMaskedColumnException(String.valueOf(columnIndex), "getURL");
+            return super.getURL(columnIndex);
+        }
+
+        @Override
+        public java.net.URL getURL(String columnLabel) throws SQLException {
+            return getURL(findColumn(columnLabel));
         }
     }
 }

--- a/src/test/java/org/pjdbc/conformance/ParameterDefaultConformanceTest.java
+++ b/src/test/java/org/pjdbc/conformance/ParameterDefaultConformanceTest.java
@@ -130,7 +130,7 @@ public class ParameterDefaultConformanceTest extends DriverConformanceTest {
             for (DriverCapability.Parameter param : driver.parameters()) {
                 assertNotNull(param.name(), "Parameter name should not be null in " + driver.name());
                 assertFalse(param.name().isEmpty(), "Parameter name should not be empty in " + driver.name());
-                assertTrue(param.name().matches("[a-zA-Z][a-zA-Z0-9_]*"),
+                assertTrue(param.name().matches("[a-zA-Z][a-zA-Z0-9_]*(\\.\\*)?"),
                     "Parameter name '" + param.name() + "' in " + driver.name() +
                     " should be a valid identifier");
             }

--- a/src/test/java/org/pjdbc/drivers/DataMaskingSecurityTest.java
+++ b/src/test/java/org/pjdbc/drivers/DataMaskingSecurityTest.java
@@ -1,0 +1,186 @@
+package org.pjdbc.drivers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.sql.Blob;
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Properties;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class DataMaskingSecurityTest {
+
+    @BeforeClass
+    public static void loadDriver() throws ClassNotFoundException {
+        Class.forName("org.pjdbc.drivers.DataMaskingDriver");
+    }
+
+    private void setupLOBTable(String dbName) throws SQLException {
+        try (Connection conn = DriverManager.getConnection("jdbc:h2:mem:" + dbName + ";DB_CLOSE_DELAY=-1")) {
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute("CREATE TABLE IF NOT EXISTS lob_data (" +
+                    "id INT PRIMARY KEY, " +
+                    "secret_clob CLOB, " +
+                    "secret_blob BLOB)");
+
+                PreparedStatement pstmt = conn.prepareStatement("INSERT INTO lob_data VALUES (?, ?, ?)");
+                pstmt.setInt(1, 1);
+                pstmt.setString(2, "This is a very secret message in a CLOB");
+                pstmt.setBytes(3, "Secret BLOB data".getBytes());
+                pstmt.executeUpdate();
+            }
+        }
+    }
+
+    @Test
+    public void testClobBypass() throws SQLException {
+        setupLOBTable("test_clob_bypass");
+        String url = "jdbc:mask[columns=secret_clob,strategy=REDACT]:jdbc:h2:mem:test_clob_bypass;DB_CLOSE_DELAY=-1";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                try (ResultSet rs = stmt.executeQuery("SELECT secret_clob FROM lob_data WHERE id = 1")) {
+                    assertTrue(rs.next());
+
+                    // getString() should be masked
+                    assertEquals("[REDACTED]", rs.getString("secret_clob"));
+
+                    // getClob() currently might NOT be masked and return the raw data!
+                    try {
+                        Clob clob = rs.getClob("secret_clob");
+                        if (clob != null) {
+                            String rawData = clob.getSubString(1, (int) clob.length());
+                            if (!"[REDACTED]".equals(rawData)) {
+                                fail("VULNERABILITY: Mask bypassed via getClob()");
+                            }
+                        }
+                    } catch (SQLException e) {
+                        // Expected after fix
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testBlobBypass() throws SQLException {
+        setupLOBTable("test_blob_bypass");
+        String url = "jdbc:mask[columns=secret_blob,strategy=REDACT]:jdbc:h2:mem:test_blob_bypass;DB_CLOSE_DELAY=-1";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                try (ResultSet rs = stmt.executeQuery("SELECT secret_blob FROM lob_data WHERE id = 1")) {
+                    assertTrue(rs.next());
+
+                    // getBlob() currently might NOT be masked
+                    try {
+                        Blob blob = rs.getBlob("secret_blob");
+                        if (blob != null) {
+                            byte[] rawData = blob.getBytes(1, (int) blob.length());
+                            String rawString = new String(rawData);
+                            if (!"[REDACTED]".equals(rawString)) {
+                                fail("VULNERABILITY: Mask bypassed via getBlob()");
+                            }
+                        }
+                    } catch (SQLException e) {
+                        // Expected after fix
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testAliasBypass() throws SQLException {
+        try (Connection conn = DriverManager.getConnection("jdbc:h2:mem:test_alias;DB_CLOSE_DELAY=-1")) {
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute("CREATE TABLE users (id INT, ssn VARCHAR(11))");
+                stmt.execute("INSERT INTO users VALUES (1, '123-45-6789')");
+            }
+        }
+
+        // Mask the 'ssn' column
+        String url = "jdbc:mask[columns=ssn,strategy=REDACT]:jdbc:h2:mem:test_alias;DB_CLOSE_DELAY=-1";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                // Alias the column: SELECT ssn AS secret_alias
+                try (ResultSet rs = stmt.executeQuery("SELECT ssn AS secret_alias FROM users WHERE id = 1")) {
+                    assertTrue(rs.next());
+
+                    // If the driver only checks the column label 'secret_alias', it might not mask it!
+                    String masked = rs.getString("secret_alias");
+                    if (!"[REDACTED]".equals(masked)) {
+                        fail("VULNERABILITY: Mask bypassed via column aliasing: " + masked);
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testGetObjectWithClassBypass() throws SQLException {
+        try (Connection conn = DriverManager.getConnection("jdbc:h2:mem:test_getobject_class;DB_CLOSE_DELAY=-1")) {
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute("CREATE TABLE users (id INT, ssn VARCHAR(11))");
+                stmt.execute("INSERT INTO users VALUES (1, '123-45-6789')");
+            }
+        }
+
+        String url = "jdbc:mask[columns=ssn,strategy=REDACT]:jdbc:h2:mem:test_getobject_class;DB_CLOSE_DELAY=-1";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                try (ResultSet rs = stmt.executeQuery("SELECT ssn FROM users WHERE id = 1")) {
+                    assertTrue(rs.next());
+
+                    // getObject(int, Class<T>) or getObject(String, Class<T>) might bypass masking
+                    try {
+                        String ssn = rs.getObject(1, String.class);
+                        if (!"[REDACTED]".equals(ssn)) {
+                            fail("VULNERABILITY: Mask bypassed via getObject(int, Class): " + ssn);
+                        }
+                    } catch (SQLException e) {
+                        // Expected after fix if it throws
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testGetObjectWithMapBypass() throws SQLException {
+        try (Connection conn = DriverManager.getConnection("jdbc:h2:mem:test_getobject_map;DB_CLOSE_DELAY=-1")) {
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute("CREATE TABLE users (id INT, ssn VARCHAR(11))");
+                stmt.execute("INSERT INTO users VALUES (1, '123-45-6789')");
+            }
+        }
+
+        String url = "jdbc:mask[columns=ssn,strategy=REDACT]:jdbc:h2:mem:test_getobject_map;DB_CLOSE_DELAY=-1";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                try (ResultSet rs = stmt.executeQuery("SELECT ssn FROM users WHERE id = 1")) {
+                    assertTrue(rs.next());
+
+                    // getObject(int, Map) or getObject(String, Map) might bypass masking
+                    try {
+                        Object ssn = rs.getObject(1, new HashMap<String, Class<?>>());
+                        if (ssn instanceof String s && !"[REDACTED]".equals(s)) {
+                            fail("VULNERABILITY: Mask bypassed via getObject(int, Map): " + s);
+                        }
+                    } catch (SQLException e) {
+                        // Expected after fix if it throws
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Data masking in `DataMaskingDriver` could be bypassed via column aliasing (e.g., `SELECT secret AS alias`) or by using LOB/complex type getters (e.g., `getBlob`, `getObject(int, Class)`).
🎯 Impact: Sensitive data that should be masked could be leaked in its original form if an attacker or developer uses these alternative methods or aliases.
🔧 Fix:
- Refactored all label-based getters in `MaskingResultSet` to delegate to index-based counterparts via `findColumn()`.
- Overrode missing `ResultSet` getters (Blob, Clob, NClob, Array, Ref, RowId, SQLXML, URL, and complex `getObject` variants) to throw a fail-secure `SQLException` for masked columns.
- Corrected a regex in `ParameterDefaultConformanceTest` to support wildcard parameter names used by some drivers.
✅ Verification: Created `DataMaskingSecurityTest.java` reproducing the bypasses and verified they are now blocked. Ran the full `mvn test -Pfast` suite (939 tests passed).

---
*PR created automatically by Jules for task [8954175953958480333](https://jules.google.com/task/8954175953958480333) started by @davidaventimiglia-professional*