### PR TITLE
🛡️ Sentinel: [HIGH] Harden SQL parsing against comment-based bypasses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel's Journal - Critical Security Learnings
+
+## 2026-03-27 - SQL Comment Bypass in Proxy Drivers
+**Vulnerability:** Security proxy drivers (Readonly, SchemaValidation) and SQL transformers used regex patterns that relied on whitespace (\s+) to separate SQL keywords. Attackers could bypass these checks by using SQL comments (/* comment */ or -- line comment) as separators, which are valid in most SQL dialects but not matched by \s+.
+**Learning:** Standard whitespace regexes are insufficient for SQL parsing when security boundaries are involved. SQL comments must be treated as valid separators between tokens.
+**Prevention:** Centralized SQL separator regexes in a utility class (SqlPatterns) that explicitly include block and line comments. Use these patterns in all security-critical regexes. When using Pattern.DOTALL, ensure line comment patterns ([^\r\n]*) do not greedily consume the rest of the query.

--- a/src/main/java/org/pjdbc/drivers/ReadonlyDriver.java
+++ b/src/main/java/org/pjdbc/drivers/ReadonlyDriver.java
@@ -11,6 +11,7 @@ import java.sql.Statement;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
+import org.pjdbc.sql.SqlPatterns;
 import org.pjdbc.annotations.DriverCapability;
 import org.pjdbc.annotations.DriverParameter;
 import org.pjdbc.annotations.DriverParameter.ParameterType;
@@ -56,19 +57,19 @@ public class ReadonlyDriver extends AbstractProxyDriver {
 
     // Pattern to detect DML write operations
     private static final Pattern DML_PATTERN = Pattern.compile(
-        "^\\s*(INSERT|UPDATE|DELETE|MERGE|UPSERT|REPLACE|TRUNCATE)\\b",
+        "^" + SqlPatterns.SQL_SEP_OPT + "(INSERT|UPDATE|DELETE|MERGE|UPSERT|REPLACE|TRUNCATE)\\b",
         Pattern.CASE_INSENSITIVE
     );
 
     // Pattern to detect DDL operations
     private static final Pattern DDL_PATTERN = Pattern.compile(
-        "^\\s*(CREATE|ALTER|DROP|RENAME)\\b",
+        "^" + SqlPatterns.SQL_SEP_OPT + "(CREATE|ALTER|DROP|RENAME)\\b",
         Pattern.CASE_INSENSITIVE
     );
 
     // Pattern to detect DCL operations
     private static final Pattern DCL_PATTERN = Pattern.compile(
-        "^\\s*(GRANT|REVOKE)\\b",
+        "^" + SqlPatterns.SQL_SEP_OPT + "(GRANT|REVOKE)\\b",
         Pattern.CASE_INSENSITIVE
     );
 

--- a/src/main/java/org/pjdbc/drivers/SchemaValidationDriver.java
+++ b/src/main/java/org/pjdbc/drivers/SchemaValidationDriver.java
@@ -18,6 +18,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.pjdbc.sql.SqlPatterns;
 import org.pjdbc.annotations.DriverCapability;
 import org.pjdbc.annotations.DriverParameter;
 import org.pjdbc.annotations.DriverParameter.ParameterType;
@@ -79,31 +80,31 @@ public class SchemaValidationDriver extends AbstractProxyDriver {
     // Pattern to extract table names from SQL
     // Matches: FROM table, JOIN table, INTO table, UPDATE table, TABLE table (for TRUNCATE)
     private static final Pattern TABLE_PATTERN = Pattern.compile(
-        "\\b(?:FROM|JOIN|INTO|UPDATE|TABLE|TRUNCATE)\\s+([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)?)",
+        "\\b(?:FROM|JOIN|INTO|UPDATE|TABLE|TRUNCATE)" + SqlPatterns.SQL_SEP + "(" + SqlPatterns.IDENTIFIER_REGEX + "(?:\\." + SqlPatterns.IDENTIFIER_REGEX + ")?)",
         Pattern.CASE_INSENSITIVE
     );
 
     // Pattern to extract column names from SELECT
     private static final Pattern SELECT_COLUMNS_PATTERN = Pattern.compile(
-        "\\bSELECT\\s+(.+?)\\s+FROM\\b",
+        "\\bSELECT" + SqlPatterns.SQL_SEP + "(.+?)" + SqlPatterns.SQL_SEP + "FROM\\b",
         Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to extract columns from INSERT
     private static final Pattern INSERT_COLUMNS_PATTERN = Pattern.compile(
-        "\\bINSERT\\s+INTO\\s+[a-zA-Z_][a-zA-Z0-9_.]*\\s*\\(([^)]+)\\)",
+        "\\bINSERT" + SqlPatterns.SQL_SEP + "INTO" + SqlPatterns.SQL_SEP + "(?:" + SqlPatterns.IDENTIFIER_REGEX + "\\.)?" + SqlPatterns.IDENTIFIER_REGEX + SqlPatterns.SQL_SEP_OPT + "\\(([^)]+)\\)",
         Pattern.CASE_INSENSITIVE
     );
 
     // Pattern to extract columns from UPDATE SET
     private static final Pattern UPDATE_COLUMNS_PATTERN = Pattern.compile(
-        "\\bSET\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
+        "\\bSET" + SqlPatterns.SQL_SEP + "(" + SqlPatterns.IDENTIFIER_REGEX + ")",
         Pattern.CASE_INSENSITIVE
     );
 
     // Pattern to parse column names (handles table.column and aliases)
     private static final Pattern COLUMN_NAME_PATTERN = Pattern.compile(
-        "([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)?)"
+        "(" + SqlPatterns.IDENTIFIER_REGEX + "(?:\\." + SqlPatterns.IDENTIFIER_REGEX + ")?)"
     );
 
     // Global configurations for external access

--- a/src/main/java/org/pjdbc/sql/SchemaTransformer.java
+++ b/src/main/java/org/pjdbc/sql/SchemaTransformer.java
@@ -42,9 +42,9 @@ public class SchemaTransformer extends AbstractJdbcTransformer {
     // - INTO tablename
     // - UPDATE tablename
     // - TABLE tablename (for TRUNCATE TABLE, etc.)
-    // Captures: keyword, optional whitespace, table name (not already qualified)
+    // Captures: keyword, separator, table name (not already qualified)
     private static final Pattern TABLE_PATTERN = Pattern.compile(
-        "\\b(FROM|JOIN|INTO|UPDATE|TABLE)\\s+(?!\\w+\\.)([a-zA-Z_][a-zA-Z0-9_]*)",
+        "\\b(FROM|JOIN|INTO|UPDATE|TABLE)(" + SqlPatterns.SQL_SEP + ")(?!" + SqlPatterns.IDENTIFIER_REGEX + "\\.)(" + SqlPatterns.IDENTIFIER_REGEX + ")",
         Pattern.CASE_INSENSITIVE
     );
 
@@ -71,9 +71,11 @@ public class SchemaTransformer extends AbstractJdbcTransformer {
 
         while (matcher.find()) {
             String keyword = matcher.group(1);
-            String tableName = matcher.group(2);
-            // Replace with: keyword + space + schema.tablename
-            matcher.appendReplacement(result, keyword + " " + schemaPrefix + tableName);
+            String separator = matcher.group(2);
+            String tableName = matcher.group(3);
+            // Replace with: keyword + original separator + schema.tablename
+            // Escape the replacement string to handle $ or \ in comments
+            matcher.appendReplacement(result, Matcher.quoteReplacement(keyword + separator + schemaPrefix + tableName));
         }
         matcher.appendTail(result);
 

--- a/src/main/java/org/pjdbc/sql/SqlPatterns.java
+++ b/src/main/java/org/pjdbc/sql/SqlPatterns.java
@@ -1,0 +1,23 @@
+package org.pjdbc.sql;
+
+/**
+ * Centralized SQL regex patterns for consistent SQL parsing across drivers.
+ * Handles SQL comments (block and line) as valid separators.
+ */
+public class SqlPatterns {
+    /**
+     * Regex for optional SQL separators (whitespace or comments).
+     * Using [^\r\n] for line comments to be safe with Pattern.DOTALL.
+     */
+    public static final String SQL_SEP_OPT = "(?:\\s+|/\\*[\\s\\S]*?\\*/|--[^\\r\\n]*)*";
+
+    /**
+     * Regex for mandatory SQL separators (at least one whitespace or comment).
+     */
+    public static final String SQL_SEP = "(?:\\s+|/\\*[\\s\\S]*?\\*/|--[^\\r\\n]*)+";
+
+    /**
+     * Regex for a standard SQL identifier.
+     */
+    public static final String IDENTIFIER_REGEX = "[a-zA-Z_][a-zA-Z0-9_]*";
+}

--- a/src/main/java/org/pjdbc/sql/WhereTransformer.java
+++ b/src/main/java/org/pjdbc/sql/WhereTransformer.java
@@ -49,13 +49,13 @@ public class WhereTransformer extends AbstractJdbcTransformer {
     // Pattern to find insertion point for new WHERE clause
     // Matches: GROUP BY, HAVING, ORDER BY, LIMIT, OFFSET, UNION, INTERSECT, EXCEPT, or end
     private static final Pattern WHERE_INSERTION_POINT = Pattern.compile(
-        "\\s+(GROUP\\s+BY|HAVING|ORDER\\s+BY|LIMIT|OFFSET|UNION|INTERSECT|EXCEPT|FOR\\s+UPDATE|FOR\\s+SHARE)\\b",
+        SqlPatterns.SQL_SEP + "(GROUP" + SqlPatterns.SQL_SEP + "BY|HAVING|ORDER" + SqlPatterns.SQL_SEP + "BY|LIMIT|OFFSET|UNION|INTERSECT|EXCEPT|FOR" + SqlPatterns.SQL_SEP + "UPDATE|FOR" + SqlPatterns.SQL_SEP + "SHARE)\\b",
         Pattern.CASE_INSENSITIVE
     );
 
     // Pattern to detect SELECT/UPDATE/DELETE statements (not INSERT)
     private static final Pattern MODIFIABLE_STATEMENT = Pattern.compile(
-        "^\\s*(SELECT|UPDATE|DELETE)\\b",
+        "^" + SqlPatterns.SQL_SEP_OPT + "(SELECT|UPDATE|DELETE)\\b",
         Pattern.CASE_INSENSITIVE
     );
 
@@ -63,7 +63,7 @@ public class WhereTransformer extends AbstractJdbcTransformer {
     // We need to find WHERE that's not inside parentheses (subquery)
     // This is a simplification - we find WHERE and append at the insertion point
     private static final Pattern WHERE_CLAUSE_END = Pattern.compile(
-        "\\bWHERE\\b(.+?)(?=(GROUP\\s+BY|HAVING|ORDER\\s+BY|LIMIT|OFFSET|UNION|INTERSECT|EXCEPT|FOR\\s+UPDATE|FOR\\s+SHARE|$))",
+        "\\bWHERE\\b(.+?)(?=(GROUP" + SqlPatterns.SQL_SEP + "BY|HAVING|ORDER" + SqlPatterns.SQL_SEP + "BY|LIMIT|OFFSET|UNION|INTERSECT|EXCEPT|FOR" + SqlPatterns.SQL_SEP + "UPDATE|FOR" + SqlPatterns.SQL_SEP + "SHARE|$))",
         Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 

--- a/src/test/java/org/pjdbc/conformance/ParameterDefaultConformanceTest.java
+++ b/src/test/java/org/pjdbc/conformance/ParameterDefaultConformanceTest.java
@@ -130,7 +130,7 @@ public class ParameterDefaultConformanceTest extends DriverConformanceTest {
             for (DriverCapability.Parameter param : driver.parameters()) {
                 assertNotNull(param.name(), "Parameter name should not be null in " + driver.name());
                 assertFalse(param.name().isEmpty(), "Parameter name should not be empty in " + driver.name());
-                assertTrue(param.name().matches("[a-zA-Z][a-zA-Z0-9_]*"),
+                assertTrue(param.name().matches("[a-zA-Z][a-zA-Z0-9_]*(\\.\\*)?"),
                     "Parameter name '" + param.name() + "' in " + driver.name() +
                     " should be a valid identifier");
             }

--- a/src/test/java/org/pjdbc/drivers/ReadonlyCommentBypassTest.java
+++ b/src/test/java/org/pjdbc/drivers/ReadonlyCommentBypassTest.java
@@ -1,0 +1,37 @@
+package org.pjdbc.drivers;
+
+import static org.junit.Assert.fail;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ReadonlyCommentBypassTest {
+
+    @BeforeClass
+    public static void loadDriver() throws ClassNotFoundException {
+        Class.forName("org.pjdbc.drivers.ReadonlyDriver");
+    }
+
+    @Test
+    public void testCommentBypass() throws SQLException {
+        String url = "jdbc:readonly:jdbc:h2:mem:test_bypass";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                // This should be blocked but might bypass if comments aren't handled
+                stmt.execute("/* comment */ INSERT INTO bypass_test VALUES (1)");
+                // If it doesn't throw, we've bypassed the check
+            }
+        } catch (SQLException e) {
+            if (e.getMessage().contains("ReadonlyDriver")) {
+                // Success - it was blocked
+                return;
+            }
+            // If it's another error (like table not found), it might still have bypassed the PJDBC check
+            // but failed in H2. However, ReadonlyDriver should check BEFORE passing to H2.
+            throw e;
+        }
+    }
+}

--- a/src/test/java/org/pjdbc/drivers/SchemaValidationBypassTest.java
+++ b/src/test/java/org/pjdbc/drivers/SchemaValidationBypassTest.java
@@ -1,0 +1,41 @@
+package org.pjdbc.drivers;
+
+import static org.junit.Assert.fail;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class SchemaValidationBypassTest {
+
+    @BeforeClass
+    public static void loadDriver() throws ClassNotFoundException {
+        Class.forName("org.pjdbc.drivers.SchemaValidationDriver");
+    }
+
+    @Test
+    public void testTableCommentBypass() throws SQLException {
+        // Whitelist only 'allowed_table'
+        String url = "jdbc:schema[allowedTables=allowed_table]:jdbc:h2:mem:test_schema_bypass";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                // This should be blocked because 'secret_table' is not allowed
+                // But it might bypass if we use a comment
+                stmt.execute("SELECT * FROM/*comment*/secret_table");
+                // If it doesn't throw a SchemaValidationDriver exception, it bypassed
+            }
+        } catch (SQLException e) {
+            if (e.getMessage().contains("SchemaValidationDriver")) {
+                // Success - it was blocked
+                return;
+            }
+            // If it's a "table not found" error from H2, it bypassed the driver's check
+            if (e.getMessage().contains("Table \"SECRET_TABLE\" not found")) {
+                fail("Bypassed SchemaValidationDriver! H2 caught the missing table instead.");
+            }
+            throw e;
+        }
+    }
+}

--- a/src/test/java/org/pjdbc/sql/TransformerCommentTest.java
+++ b/src/test/java/org/pjdbc/sql/TransformerCommentTest.java
@@ -1,0 +1,32 @@
+package org.pjdbc.sql;
+
+import static org.junit.Assert.assertEquals;
+import java.sql.SQLException;
+import org.junit.Test;
+
+public class TransformerCommentTest {
+
+    @Test
+    public void testSchemaTransformerWithComments() throws SQLException {
+        SchemaTransformer transformer = new SchemaTransformer("my_schema");
+        String sql = "SELECT * FROM/*comment*/users";
+        String expected = "SELECT * FROM/*comment*/my_schema.users";
+        assertEquals(expected, transformer.transformSql(sql));
+    }
+
+    @Test
+    public void testWhereTransformerWithComments() throws SQLException {
+        WhereTransformer transformer = new WhereTransformer("deleted=false");
+        String sql = "/* leading comment */ SELECT * FROM users";
+        String expected = "/* leading comment */ SELECT * FROM users WHERE deleted=false";
+        assertEquals(expected, transformer.transformSql(sql));
+    }
+
+    @Test
+    public void testWhereTransformerInsertionPointWithComments() throws SQLException {
+        WhereTransformer transformer = new WhereTransformer("deleted=false");
+        String sql = "SELECT * FROM users/*comment*/ORDER/*comment*/BY name";
+        String expected = "SELECT * FROM users WHERE deleted=false/*comment*/ORDER/*comment*/BY name";
+        assertEquals(expected, transformer.transformSql(sql));
+    }
+}


### PR DESCRIPTION
I have hardened the SQL parsing logic across several PJDBC drivers and transformers to prevent security bypasses using SQL comments. 

Specifically, I:
1.  **Centralized SQL Patterns**: Created `org.pjdbc.sql.SqlPatterns` to provide `SQL_SEP` and `SQL_SEP_OPT` regexes that correctly handle both block comments (`/*...*/`) and line comments (`--...`).
2.  **Hardened Drivers**: Updated `ReadonlyDriver` and `SchemaValidationDriver` to use these patterns, closing a bypass where a query like `/*comment*/INSERT...` would not be blocked as a DML write.
3.  **Improved Transformers**: Updated `SchemaTransformer` and `WhereTransformer` to handle comments correctly, preventing them from missing transformation points or mangling SQL when comments are present.
4.  **Preserved SQL Integrity**: Updated `SchemaTransformer` to capture and preserve the original separator (including comments) during replacement, and used `Matcher.quoteReplacement` to handle special characters safely.
5.  **Fixed Conformance Tests**: Updated `ParameterDefaultConformanceTest` to support the wildcard parameter naming convention (`rename.*`) used by `FilterDriver`.
6.  **Added Security Tests**: Created `ReadonlyCommentBypassTest`, `SchemaValidationBypassTest`, and `TransformerCommentTest` to verify the fixes and prevent regressions.
7.  **Journaled Learnings**: Added a critical security learning to `.jules/sentinel.md` regarding SQL comment handling in regex-based parsers.

All tests passed, including the new security tests and the full project test suite.

---
*PR created automatically by Jules for task [15737011932286255076](https://jules.google.com/task/15737011932286255076) started by @davidaventimiglia-professional*