### PR TITLE
🛡️ Sentinel: [HIGH] Fix SQL comment-based security bypasses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2026-04-02 - SQL Comment Bypass in Regex Parsing
+**Vulnerability:** Security drivers (ReadonlyDriver, SchemaValidationDriver) and SQL transformers (WhereTransformer, SchemaTransformer) used simple whitespace regexes (\s+ or \s*) to identify SQL keywords and boundaries. This allowed bypassing security checks by using SQL comments (/* comment */ or -- line comment) instead of whitespace.
+**Learning:** Databases treat SQL comments as valid separators between tokens. Simple whitespace-based regexes fail to account for this, creating a significant bypass vector in proxy-based security controls.
+**Prevention:** Centralize SQL separator patterns in a utility class (SqlPatterns) that includes both whitespace and SQL comment syntax. Use these robust patterns (SQL_SEP and SQL_SEP_OPT) in all security-critical regexes.

--- a/src/main/java/org/pjdbc/drivers/FederatingDriver.java
+++ b/src/main/java/org/pjdbc/drivers/FederatingDriver.java
@@ -13,6 +13,7 @@ import org.pjdbc.annotations.DriverParameter.ParameterType;
 import org.pjdbc.annotations.DriverSideEffects;
 import org.pjdbc.sql.*;
 import static org.pjdbc.sql.PjdbcListeners.fireFederatedQuery;
+import org.pjdbc.sql.SqlPatterns;
 
 /**
  * FederatingDriver queries multiple databases and merges results.
@@ -102,7 +103,7 @@ public class FederatingDriver extends AbstractDriver {
      * Matches: FROM table, JOIN table, INTO table, UPDATE table, TABLE table (for TRUNCATE)
      */
     private static final java.util.regex.Pattern TABLE_PATTERN = java.util.regex.Pattern.compile(
-        "\\b(?:FROM|JOIN|INTO|UPDATE|TABLE|TRUNCATE)\\s+([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)?)",
+        "\\b(?:FROM|JOIN|INTO|UPDATE|TABLE|TRUNCATE)" + SqlPatterns.SQL_SEP + "([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)?)",
         java.util.regex.Pattern.CASE_INSENSITIVE
     );
 

--- a/src/main/java/org/pjdbc/drivers/ReadonlyDriver.java
+++ b/src/main/java/org/pjdbc/drivers/ReadonlyDriver.java
@@ -11,6 +11,7 @@ import java.sql.Statement;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
+import org.pjdbc.sql.SqlPatterns;
 import org.pjdbc.annotations.DriverCapability;
 import org.pjdbc.annotations.DriverParameter;
 import org.pjdbc.annotations.DriverParameter.ParameterType;
@@ -56,19 +57,19 @@ public class ReadonlyDriver extends AbstractProxyDriver {
 
     // Pattern to detect DML write operations
     private static final Pattern DML_PATTERN = Pattern.compile(
-        "^\\s*(INSERT|UPDATE|DELETE|MERGE|UPSERT|REPLACE|TRUNCATE)\\b",
+        "^" + SqlPatterns.SQL_SEP_OPT + "(INSERT|UPDATE|DELETE|MERGE|UPSERT|REPLACE|TRUNCATE)\\b",
         Pattern.CASE_INSENSITIVE
     );
 
     // Pattern to detect DDL operations
     private static final Pattern DDL_PATTERN = Pattern.compile(
-        "^\\s*(CREATE|ALTER|DROP|RENAME)\\b",
+        "^" + SqlPatterns.SQL_SEP_OPT + "(CREATE|ALTER|DROP|RENAME)\\b",
         Pattern.CASE_INSENSITIVE
     );
 
     // Pattern to detect DCL operations
     private static final Pattern DCL_PATTERN = Pattern.compile(
-        "^\\s*(GRANT|REVOKE)\\b",
+        "^" + SqlPatterns.SQL_SEP_OPT + "(GRANT|REVOKE)\\b",
         Pattern.CASE_INSENSITIVE
     );
 

--- a/src/main/java/org/pjdbc/drivers/SchemaValidationDriver.java
+++ b/src/main/java/org/pjdbc/drivers/SchemaValidationDriver.java
@@ -18,6 +18,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.pjdbc.sql.SqlPatterns;
 import org.pjdbc.annotations.DriverCapability;
 import org.pjdbc.annotations.DriverParameter;
 import org.pjdbc.annotations.DriverParameter.ParameterType;
@@ -79,25 +80,25 @@ public class SchemaValidationDriver extends AbstractProxyDriver {
     // Pattern to extract table names from SQL
     // Matches: FROM table, JOIN table, INTO table, UPDATE table, TABLE table (for TRUNCATE)
     private static final Pattern TABLE_PATTERN = Pattern.compile(
-        "\\b(?:FROM|JOIN|INTO|UPDATE|TABLE|TRUNCATE)\\s+([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)?)",
+        "\\b(FROM|JOIN|INTO|UPDATE|TABLE|TRUNCATE)" + SqlPatterns.SQL_SEP + "([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)?)",
         Pattern.CASE_INSENSITIVE
     );
 
     // Pattern to extract column names from SELECT
     private static final Pattern SELECT_COLUMNS_PATTERN = Pattern.compile(
-        "\\bSELECT\\s+(.+?)\\s+FROM\\b",
+        "\\bSELECT" + SqlPatterns.SQL_SEP + "(.+?)" + SqlPatterns.SQL_SEP + "FROM\\b",
         Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to extract columns from INSERT
     private static final Pattern INSERT_COLUMNS_PATTERN = Pattern.compile(
-        "\\bINSERT\\s+INTO\\s+[a-zA-Z_][a-zA-Z0-9_.]*\\s*\\(([^)]+)\\)",
+        "\\bINSERT" + SqlPatterns.SQL_SEP + "INTO" + SqlPatterns.SQL_SEP + "[a-zA-Z_][a-zA-Z0-9_.]*" + SqlPatterns.SQL_SEP_OPT + "\\(([^)]+)\\)",
         Pattern.CASE_INSENSITIVE
     );
 
     // Pattern to extract columns from UPDATE SET
     private static final Pattern UPDATE_COLUMNS_PATTERN = Pattern.compile(
-        "\\bSET\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
+        "\\bSET" + SqlPatterns.SQL_SEP + "([a-zA-Z_][a-zA-Z0-9_]*)",
         Pattern.CASE_INSENSITIVE
     );
 
@@ -302,7 +303,7 @@ public class SchemaValidationDriver extends AbstractProxyDriver {
             Set<String> tables = new HashSet<>();
             Matcher matcher = TABLE_PATTERN.matcher(sql);
             while (matcher.find()) {
-                String table = matcher.group(1);
+                String table = matcher.group(2);
                 // Handle schema.table format - extract just table name
                 if (table.contains(".")) {
                     table = table.substring(table.lastIndexOf('.') + 1);

--- a/src/main/java/org/pjdbc/sql/SchemaTransformer.java
+++ b/src/main/java/org/pjdbc/sql/SchemaTransformer.java
@@ -44,7 +44,7 @@ public class SchemaTransformer extends AbstractJdbcTransformer {
     // - TABLE tablename (for TRUNCATE TABLE, etc.)
     // Captures: keyword, optional whitespace, table name (not already qualified)
     private static final Pattern TABLE_PATTERN = Pattern.compile(
-        "\\b(FROM|JOIN|INTO|UPDATE|TABLE)\\s+(?!\\w+\\.)([a-zA-Z_][a-zA-Z0-9_]*)",
+        "\\b(FROM|JOIN|INTO|UPDATE|TABLE)" + SqlPatterns.SQL_SEP + "(?!\\w+\\.)([a-zA-Z_][a-zA-Z0-9_]*)",
         Pattern.CASE_INSENSITIVE
     );
 

--- a/src/main/java/org/pjdbc/sql/SqlPatterns.java
+++ b/src/main/java/org/pjdbc/sql/SqlPatterns.java
@@ -1,0 +1,19 @@
+package org.pjdbc.sql;
+
+/**
+ * Centralized SQL patterns for robust parsing.
+ * Handles whitespace and SQL comments (block and line).
+ */
+public class SqlPatterns {
+    /**
+     * Regex for optional SQL separator: whitespace, block comments, or line comments.
+     */
+    public static final String SQL_SEP_OPT = "(?:\\s+|/\\*[\\s\\S]*?\\*/|--[^\\r\\n]*)*";
+
+    /**
+     * Regex for mandatory SQL separator: at least one whitespace, block comment, or line comment.
+     */
+    public static final String SQL_SEP = "(?:\\s+|/\\*[\\s\\S]*?\\*/|--[^\\r\\n]*)+";
+
+    private SqlPatterns() {}
+}

--- a/src/main/java/org/pjdbc/sql/WhereTransformer.java
+++ b/src/main/java/org/pjdbc/sql/WhereTransformer.java
@@ -55,7 +55,7 @@ public class WhereTransformer extends AbstractJdbcTransformer {
 
     // Pattern to detect SELECT/UPDATE/DELETE statements (not INSERT)
     private static final Pattern MODIFIABLE_STATEMENT = Pattern.compile(
-        "^\\s*(SELECT|UPDATE|DELETE)\\b",
+        "^" + SqlPatterns.SQL_SEP_OPT + "(SELECT|UPDATE|DELETE)\\b",
         Pattern.CASE_INSENSITIVE
     );
 

--- a/src/test/java/org/pjdbc/conformance/ParameterDefaultConformanceTest.java
+++ b/src/test/java/org/pjdbc/conformance/ParameterDefaultConformanceTest.java
@@ -130,9 +130,9 @@ public class ParameterDefaultConformanceTest extends DriverConformanceTest {
             for (DriverCapability.Parameter param : driver.parameters()) {
                 assertNotNull(param.name(), "Parameter name should not be null in " + driver.name());
                 assertFalse(param.name().isEmpty(), "Parameter name should not be empty in " + driver.name());
-                assertTrue(param.name().matches("[a-zA-Z][a-zA-Z0-9_]*"),
+                assertTrue(param.name().matches("[a-zA-Z][a-zA-Z0-9_]*(\\.\\*)?"),
                     "Parameter name '" + param.name() + "' in " + driver.name() +
-                    " should be a valid identifier");
+                    " should be a valid identifier or wildcard");
             }
         }
     }

--- a/src/test/java/org/pjdbc/drivers/ReadonlyBypassTest.java
+++ b/src/test/java/org/pjdbc/drivers/ReadonlyBypassTest.java
@@ -1,0 +1,42 @@
+package org.pjdbc.drivers;
+
+import static org.junit.Assert.fail;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ReadonlyBypassTest {
+    @BeforeClass
+    public static void loadDriver() throws ClassNotFoundException {
+        Class.forName("org.pjdbc.drivers.ReadonlyDriver");
+    }
+
+    @Test
+    public void testCommentBypass() throws SQLException {
+        String baseH2Url = "jdbc:h2:mem:test_bypass;DB_CLOSE_DELAY=-1";
+        // Setup table using direct connection
+        try (Connection conn = DriverManager.getConnection(baseH2Url)) {
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute("CREATE TABLE test (id INT)");
+            }
+        }
+
+        String readonlyUrl = "jdbc:readonly:" + baseH2Url;
+        try (Connection conn = DriverManager.getConnection(readonlyUrl)) {
+            try (Statement stmt = conn.createStatement()) {
+                // This should be blocked but will pass due to leading comment
+                try {
+                    stmt.execute("/* comment */ INSERT INTO test VALUES (1)");
+                    // If we are here, it bypassed!
+                } catch (SQLException e) {
+                    // If it's blocked, then there's no bypass (unexpected for current code)
+                    return;
+                }
+                fail("Should have blocked INSERT with leading comment");
+            }
+        }
+    }
+}

--- a/src/test/java/org/pjdbc/drivers/SchemaValidationCommentBypassTest.java
+++ b/src/test/java/org/pjdbc/drivers/SchemaValidationCommentBypassTest.java
@@ -1,0 +1,92 @@
+package org.pjdbc.drivers;
+
+import static org.junit.Assert.fail;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class SchemaValidationCommentBypassTest {
+    @BeforeClass
+    public static void loadDriver() throws ClassNotFoundException {
+        Class.forName("org.pjdbc.drivers.SchemaValidationDriver");
+    }
+
+    @Test
+    public void testTableCommentBypass() throws SQLException {
+        String baseH2Url = "jdbc:h2:mem:test_schema_bypass;DB_CLOSE_DELAY=-1";
+        // Setup tables using direct connection
+        try (Connection conn = DriverManager.getConnection(baseH2Url)) {
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute("CREATE TABLE allowed_table (id INT)");
+                stmt.execute("CREATE TABLE secret_table (id INT)");
+            }
+        }
+
+        // Whitelist mode: only allow allowed_table
+        String schemaUrl = "jdbc:schema[allowedTables=allowed_table,mode=whitelist]:" + baseH2Url;
+        try (Connection conn = DriverManager.getConnection(schemaUrl)) {
+            try (Statement stmt = conn.createStatement()) {
+                // Normal access to allowed table
+                stmt.executeQuery("SELECT * FROM allowed_table");
+
+                // Normal access to secret table should be blocked
+                try {
+                    stmt.executeQuery("SELECT * FROM secret_table");
+                    fail("Should have blocked access to secret_table");
+                } catch (SQLException e) {
+                    // Expected
+                }
+
+                // Bypass attempt using comments
+                try {
+                    stmt.executeQuery("SELECT * FROM/* comment */secret_table");
+                    fail("Should have blocked access to secret_table with comment separator");
+                } catch (SQLException e) {
+                    // Expected
+                }
+
+                try {
+                    stmt.executeQuery("SELECT * FROM --\nsecret_table");
+                    fail("Should have blocked access to secret_table with line comment separator");
+                } catch (SQLException e) {
+                    // Expected
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testColumnCommentBypass() throws SQLException {
+        String baseH2Url = "jdbc:h2:mem:test_column_bypass;DB_CLOSE_DELAY=-1";
+        try (Connection conn = DriverManager.getConnection(baseH2Url)) {
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute("CREATE TABLE users (id INT, ssn VARCHAR(10))");
+            }
+        }
+
+        // Block ssn column
+        String schemaUrl = "jdbc:schema[blockedColumns=ssn]:" + baseH2Url;
+        try (Connection conn = DriverManager.getConnection(schemaUrl)) {
+            try (Statement stmt = conn.createStatement()) {
+                // Normal access to ssn should be blocked
+                try {
+                    stmt.executeQuery("SELECT ssn FROM users");
+                    fail("Should have blocked access to ssn column");
+                } catch (SQLException e) {
+                    // Expected
+                }
+
+                // Bypass attempt using comments in SELECT
+                try {
+                    stmt.executeQuery("SELECT/* comment */ssn FROM users");
+                    fail("Should have blocked access to ssn column with comment in SELECT");
+                } catch (SQLException e) {
+                    // Expected
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### 🛡️ Sentinel Security Report

**🚨 Severity:** HIGH
**💡 Vulnerability:** SQL Comment-Based Security Bypass
**🎯 Impact:** Malicious actors could bypass security controls in `ReadonlyDriver` (e.g., executing writes) or `SchemaValidationDriver` (e.g., accessing blocked tables/columns) by using SQL comments as separators instead of whitespace.
**🔧 Fix:** 
- Centralized SQL separator regexes in a new `SqlPatterns` utility class that explicitly accounts for block and line comments.
- Refactored regex patterns in `ReadonlyDriver`, `SchemaValidationDriver`, `FederatingDriver`, `WhereTransformer`, and `SchemaTransformer` to use these robust separators.
- Updated the conformance test to allow wildcard parameter names (e.g., `rename.*`) used by `FilterDriver`.
**✅ Verification:** 
- Created `ReadonlyBypassTest.java` and `SchemaValidationCommentBypassTest.java` which specifically attempt to bypass security using comments.
- Verified that these tests fail without the fix and pass with it.
- Ran the full test suite (`mvn test -Pfast`) to ensure no regressions.

---
*PR created automatically by Jules for task [11119635882726862702](https://jules.google.com/task/11119635882726862702) started by @davidaventimiglia-professional*