### PR TITLE
🛡️ Sentinel: [HIGH] Fix leading comment bypass in ReadonlyDriver

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-03 - [Leading Comment Bypass in SQL Parsing]
+**Vulnerability:** Security-critical SQL regexes (DML/DDL detection) used `^\\s*`, allowing bypasses via leading SQL comments (e.g., `/* comment */ INSERT...`).
+**Learning:** Standard whitespace matches in regex do not account for SQL comments, which databases often treat as valid separators before or between keywords.
+**Prevention:** Always use a centralized, comment-aware separator pattern (like `SqlPatterns.SQL_SEP_OPT`) when anchoring SQL detection regexes at the start of a statement.

--- a/src/main/java/org/pjdbc/drivers/ReadonlyDriver.java
+++ b/src/main/java/org/pjdbc/drivers/ReadonlyDriver.java
@@ -11,6 +11,7 @@ import java.sql.Statement;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
+import org.pjdbc.sql.SqlPatterns;
 import org.pjdbc.annotations.DriverCapability;
 import org.pjdbc.annotations.DriverParameter;
 import org.pjdbc.annotations.DriverParameter.ParameterType;
@@ -56,19 +57,19 @@ public class ReadonlyDriver extends AbstractProxyDriver {
 
     // Pattern to detect DML write operations
     private static final Pattern DML_PATTERN = Pattern.compile(
-        "^\\s*(INSERT|UPDATE|DELETE|MERGE|UPSERT|REPLACE|TRUNCATE)\\b",
+        "^" + SqlPatterns.SQL_SEP_OPT + "(INSERT|UPDATE|DELETE|MERGE|UPSERT|REPLACE|TRUNCATE)\\b",
         Pattern.CASE_INSENSITIVE
     );
 
     // Pattern to detect DDL operations
     private static final Pattern DDL_PATTERN = Pattern.compile(
-        "^\\s*(CREATE|ALTER|DROP|RENAME)\\b",
+        "^" + SqlPatterns.SQL_SEP_OPT + "(CREATE|ALTER|DROP|RENAME)\\b",
         Pattern.CASE_INSENSITIVE
     );
 
     // Pattern to detect DCL operations
     private static final Pattern DCL_PATTERN = Pattern.compile(
-        "^\\s*(GRANT|REVOKE)\\b",
+        "^" + SqlPatterns.SQL_SEP_OPT + "(GRANT|REVOKE)\\b",
         Pattern.CASE_INSENSITIVE
     );
 

--- a/src/main/java/org/pjdbc/sql/SqlPatterns.java
+++ b/src/main/java/org/pjdbc/sql/SqlPatterns.java
@@ -1,0 +1,16 @@
+package org.pjdbc.sql;
+
+/**
+ * Common SQL regular expression patterns.
+ */
+public class SqlPatterns {
+    /**
+     * Regex for one or more SQL separators (whitespace or comments).
+     */
+    public static final String SQL_SEP = "(?:\\s+|/\\*[\\s\\S]*?\\*/|--[^\\r\\n]*)+";
+
+    /**
+     * Regex for zero or more SQL separators (whitespace or comments).
+     */
+    public static final String SQL_SEP_OPT = "(?:\\s+|/\\*[\\s\\S]*?\\*/|--[^\\r\\n]*)*";
+}

--- a/src/test/java/org/pjdbc/conformance/ParameterDefaultConformanceTest.java
+++ b/src/test/java/org/pjdbc/conformance/ParameterDefaultConformanceTest.java
@@ -130,9 +130,9 @@ public class ParameterDefaultConformanceTest extends DriverConformanceTest {
             for (DriverCapability.Parameter param : driver.parameters()) {
                 assertNotNull(param.name(), "Parameter name should not be null in " + driver.name());
                 assertFalse(param.name().isEmpty(), "Parameter name should not be empty in " + driver.name());
-                assertTrue(param.name().matches("[a-zA-Z][a-zA-Z0-9_]*"),
+                assertTrue(param.name().matches("[a-zA-Z][a-zA-Z0-9_]*(\\.\\*)?"),
                     "Parameter name '" + param.name() + "' in " + driver.name() +
-                    " should be a valid identifier");
+                    " should be a valid identifier or wildcard pattern");
             }
         }
     }

--- a/src/test/java/org/pjdbc/drivers/ReadonlyCommentBypassTest.java
+++ b/src/test/java/org/pjdbc/drivers/ReadonlyCommentBypassTest.java
@@ -1,0 +1,66 @@
+package org.pjdbc.drivers;
+
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ReadonlyCommentBypassTest {
+
+    @BeforeClass
+    public static void loadDriver() throws ClassNotFoundException {
+        Class.forName("org.pjdbc.drivers.ReadonlyDriver");
+    }
+
+    private void assertBlocked(String sql) throws SQLException {
+        String url = "jdbc:readonly:jdbc:h2:mem:test_bypass";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute(sql);
+                fail("Expected SQLException for: " + sql);
+            }
+        } catch (SQLException e) {
+            if (e.getMessage().contains("ReadonlyDriver") && e.getMessage().contains("blocked")) {
+                // Correctly blocked
+                return;
+            }
+            fail("Expected ReadonlyDriver to block the statement, but got: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testBlockCommentBypass() throws SQLException {
+        assertBlocked("/* bypass */ INSERT INTO test_table VALUES (1)");
+    }
+
+    @Test
+    public void testLineCommentBypass() throws SQLException {
+        assertBlocked("-- bypass\nINSERT INTO test_table VALUES (1)");
+    }
+
+    @Test
+    public void testMultiLineCommentBypass() throws SQLException {
+        assertBlocked("/* \n multi \n line \n */ UPDATE test_table SET x=1");
+    }
+
+    @Test
+    public void testMixedCommentBypass() throws SQLException {
+        assertBlocked("/* comm */ -- line \n /* comm */ DELETE FROM test_table");
+    }
+
+    @Test
+    public void testDDLCommentBypass() throws SQLException {
+        assertBlocked("/* bypass */ CREATE TABLE test (id INT)");
+    }
+
+    @Test
+    public void testDCLCommentBypass() throws SQLException {
+        assertBlocked("/* bypass */ GRANT SELECT ON test TO user");
+    }
+}


### PR DESCRIPTION
This PR fixes a high-priority security vulnerability in the `ReadonlyDriver` where the use of leading SQL comments (e.g., `/* bypass */ INSERT...`) would bypass the driver's write operation detection.

### Changes
- Created `org.pjdbc.sql.SqlPatterns` to provide centralized, comment-aware SQL separator regexes (`SQL_SEP` and `SQL_SEP_OPT`).
- Modified `ReadonlyDriver` to use `SqlPatterns.SQL_SEP_OPT` instead of `\\s*` at the start of its DML, DDL, and DCL detection patterns.
- Added `ReadonlyCommentBypassTest` to verify that various types of comments (block, line, mixed, multi-line) are correctly handled.
- Updated `ParameterDefaultConformanceTest` to support wildcard parameter names (e.g., `rename.*`) used in some drivers.

### Verification
- Ran `mvn test -Dtest=ReadonlyCommentBypassTest,ReadonlyDriverTest` - All passed.
- Ran `mvn test -Pfast` - All passed.
- Manually verified the fix with a reproduction script.

---
*PR created automatically by Jules for task [4561725902652408759](https://jules.google.com/task/4561725902652408759) started by @davidaventimiglia-professional*