### PR TITLE
🛡️ Sentinel: [HIGH] Fix SQL comment-based security bypasses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-12 - Regex Bypass via SQL Comments
+**Vulnerability:** Regex-based SQL security filters (ReadonlyDriver, SchemaValidationDriver) could be bypassed by prefixing statements with SQL comments (/*...*/ or --...) or using them as delimiters where whitespace was expected.
+**Learning:** Standard regex anchors like ^ and whitespace \s are insufficient when SQL allows comments almost anywhere. Lookahead assertions are necessary in complex extractions to prevent greedy matches from consuming subsequent keywords (e.g., JOIN).
+**Prevention:** Always use a robust whitespace-or-comment pattern (?:\s|/\*.*?\*/|--.*?(?:\n|$))+ and Pattern.DOTALL. For identifier extraction, use non-greedy matches combined with lookahead for SQL reserved words.

--- a/src/main/java/org/pjdbc/drivers/ReadonlyDriver.java
+++ b/src/main/java/org/pjdbc/drivers/ReadonlyDriver.java
@@ -56,20 +56,20 @@ public class ReadonlyDriver extends AbstractProxyDriver {
 
     // Pattern to detect DML write operations
     private static final Pattern DML_PATTERN = Pattern.compile(
-        "^\\s*(INSERT|UPDATE|DELETE|MERGE|UPSERT|REPLACE|TRUNCATE)\\b",
-        Pattern.CASE_INSENSITIVE
+        "^(?:\\s|/\\*.*?\\*/|--.*?(?:\\n|$))*(INSERT|UPDATE|DELETE|MERGE|UPSERT|REPLACE|TRUNCATE)\\b",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to detect DDL operations
     private static final Pattern DDL_PATTERN = Pattern.compile(
-        "^\\s*(CREATE|ALTER|DROP|RENAME)\\b",
-        Pattern.CASE_INSENSITIVE
+        "^(?:\\s|/\\*.*?\\*/|--.*?(?:\\n|$))*(CREATE|ALTER|DROP|RENAME)\\b",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to detect DCL operations
     private static final Pattern DCL_PATTERN = Pattern.compile(
-        "^\\s*(GRANT|REVOKE)\\b",
-        Pattern.CASE_INSENSITIVE
+        "^(?:\\s|/\\*.*?\\*/|--.*?(?:\\n|$))*(GRANT|REVOKE)\\b",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     static {

--- a/src/main/java/org/pjdbc/drivers/SchemaValidationDriver.java
+++ b/src/main/java/org/pjdbc/drivers/SchemaValidationDriver.java
@@ -79,8 +79,8 @@ public class SchemaValidationDriver extends AbstractProxyDriver {
     // Pattern to extract table names from SQL
     // Matches: FROM table, JOIN table, INTO table, UPDATE table, TABLE table (for TRUNCATE)
     private static final Pattern TABLE_PATTERN = Pattern.compile(
-        "\\b(?:FROM|JOIN|INTO|UPDATE|TABLE|TRUNCATE)\\s+([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)?)",
-        Pattern.CASE_INSENSITIVE
+        "\\b(?:FROM|JOIN|INTO|UPDATE|TABLE|TRUNCATE)(?:\\s|/\\*.*?\\*/|--.*?(?:\\n|$))+([a-zA-Z0-9_.,\\s/\\*\\-]*?)(?=\\b(?:WHERE|GROUP|HAVING|ORDER|LIMIT|OFFSET|UNION|JOIN|ON|USING|VALUES|RETURNING|FOR|SET|\\)|$)|;)",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to extract column names from SELECT
@@ -302,12 +302,22 @@ public class SchemaValidationDriver extends AbstractProxyDriver {
             Set<String> tables = new HashSet<>();
             Matcher matcher = TABLE_PATTERN.matcher(sql);
             while (matcher.find()) {
-                String table = matcher.group(1);
-                // Handle schema.table format - extract just table name
-                if (table.contains(".")) {
-                    table = table.substring(table.lastIndexOf('.') + 1);
+                String group = matcher.group(1);
+                if (group == null) continue;
+                // Handle comma separated tables and potential comments within the list
+                String[] parts = group.split(",");
+                for (String part : parts) {
+                    // Strip comments from the part
+                    String cleanPart = part.replaceAll("/\\*.*?\\*/", "").replaceAll("--.*?(?:\\n|$)", "").trim();
+                    if (cleanPart.isEmpty()) continue;
+                    // Take the first word (handles table aliases)
+                    String table = cleanPart.split("\\s+")[0];
+                    // Handle schema.table format - extract just table name
+                    if (table.contains(".")) {
+                        table = table.substring(table.lastIndexOf('.') + 1);
+                    }
+                    tables.add(caseSensitive ? table : table.toLowerCase());
                 }
-                tables.add(caseSensitive ? table : table.toLowerCase());
             }
             return tables;
         }

--- a/src/test/java/org/pjdbc/conformance/ParameterDefaultConformanceTest.java
+++ b/src/test/java/org/pjdbc/conformance/ParameterDefaultConformanceTest.java
@@ -130,7 +130,7 @@ public class ParameterDefaultConformanceTest extends DriverConformanceTest {
             for (DriverCapability.Parameter param : driver.parameters()) {
                 assertNotNull(param.name(), "Parameter name should not be null in " + driver.name());
                 assertFalse(param.name().isEmpty(), "Parameter name should not be empty in " + driver.name());
-                assertTrue(param.name().matches("[a-zA-Z][a-zA-Z0-9_]*"),
+                assertTrue(param.name().matches("[a-zA-Z][a-zA-Z0-9_]*(\\.\\*)?"),
                     "Parameter name '" + param.name() + "' in " + driver.name() +
                     " should be a valid identifier");
             }

--- a/src/test/java/org/pjdbc/drivers/ReadonlyCommentBypassTest.java
+++ b/src/test/java/org/pjdbc/drivers/ReadonlyCommentBypassTest.java
@@ -1,0 +1,43 @@
+package org.pjdbc.drivers;
+
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ReadonlyCommentBypassTest {
+
+    @BeforeClass
+    public static void loadDriver() throws ClassNotFoundException {
+        Class.forName("org.pjdbc.drivers.ReadonlyDriver");
+    }
+
+    @Test
+    public void testCommentBypass() throws SQLException {
+        String url = "jdbc:readonly:jdbc:h2:mem:test_bypass";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                // This should be blocked, but it's likely not because of the leading comment
+                stmt.execute("/* comment */ INSERT INTO test_table VALUES (1)");
+                // If we get here, it bypassed the check (or the table doesn't exist, but the check should happen BEFORE execution)
+            }
+        } catch (SQLException e) {
+            if (e.getMessage().contains("ReadonlyDriver") && e.getMessage().contains("DML blocked")) {
+                // Blocked as expected
+                return;
+            }
+            // Other SQL error (like table not found) is also acceptable as long as it's not a bypass,
+            // but ReadonlyDriver should throw its own exception first.
+            if (e.getMessage().contains("Table \"TEST_TABLE\" not found")) {
+                 fail("Bypassed ReadonlyDriver check, failed at database level instead");
+            }
+            throw e;
+        }
+    }
+}

--- a/src/test/java/org/pjdbc/drivers/SchemaValidationCommentBypassTest.java
+++ b/src/test/java/org/pjdbc/drivers/SchemaValidationCommentBypassTest.java
@@ -1,0 +1,60 @@
+package org.pjdbc.drivers;
+
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class SchemaValidationCommentBypassTest {
+
+    @BeforeClass
+    public static void loadDriver() throws ClassNotFoundException {
+        Class.forName("org.pjdbc.drivers.SchemaValidationDriver");
+    }
+
+    private void assertBlocked(String url, String sql, String bypassType) throws SQLException {
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute(sql);
+                fail("Bypassed SchemaValidationDriver check (" + bypassType + "), expected SQLException");
+            }
+        } catch (SQLException e) {
+            if (e.getMessage().contains("SchemaValidationDriver") && e.getMessage().contains("blocked")) {
+                // Blocked as expected
+                return;
+            }
+            // If we get here, it means it was NOT blocked by our driver.
+            // It might have failed at database level because table doesn't exist.
+            // We want to FAIL the test if it wasn't blocked by our driver.
+            fail("Bypassed SchemaValidationDriver check (" + bypassType + "), error: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testCommentBypass() throws SQLException {
+        String url = "jdbc:schema[blockedTables=secret_table,mode=blacklist]:jdbc:h2:mem:test_schema_bypass";
+
+        assertBlocked(url, "/* comment */ SELECT * FROM secret_table", "leading comment");
+        assertBlocked(url, "SELECT * FROM/*comment*/secret_table", "delimiter comment");
+    }
+
+    @Test
+    public void testCommaSeparatedBypass() throws SQLException {
+        String url = "jdbc:schema[blockedTables=secret_table,mode=blacklist]:jdbc:h2:mem:test_schema_bypass_comma";
+
+        assertBlocked(url, "SELECT * FROM public_table, secret_table", "comma separated tables");
+    }
+
+    @Test
+    public void testJoinBypass() throws SQLException {
+        String url = "jdbc:schema[blockedTables=secret_table,mode=blacklist]:jdbc:h2:mem:test_schema_bypass_join";
+
+        assertBlocked(url, "SELECT * FROM public_table JOIN secret_table ON 1=1", "join tables");
+    }
+}


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: SQL security filters (ReadonlyDriver, SchemaValidationDriver) could be bypassed by using SQL comments (/*...*/ or --...) at the start of a query or as delimiters between keywords.
🎯 Impact: Attackers could execute prohibited DML/DDL operations on read-only connections or access unauthorized tables in schema-validated connections.
🔧 Fix:
- Updated ReadonlyDriver regex patterns to account for leading comments and whitespace using Pattern.DOTALL.
- Updated SchemaValidationDriver TABLE_PATTERN to handle comments as delimiters and support comma-separated table lists.
- Refined SchemaValidationDriver regex with lookahead to prevent greedy consumption of subsequent SQL keywords (fixing a potential bypass regression identified in review).
- Updated ParameterDefaultConformanceTest to allow 'rename.*' as a valid parameter name for FilterDriver.
✅ Verification:
- Created ReadonlyCommentBypassTest.java and SchemaValidationCommentBypassTest.java verifying that comments no longer bypass security checks.
- Verified that comma-separated tables and JOIN clauses are correctly validated in SchemaValidationDriver.
- All relevant tests and the fast test suite pass.

---
*PR created automatically by Jules for task [9185889623012662512](https://jules.google.com/task/9185889623012662512) started by @davidaventimiglia-professional*