### PR TITLE
🛡️ Sentinel: [HIGH] Harden SQL regex patterns against comment-based bypasses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-05-16 - SQL Comment-Based Security Bypass
+**Vulnerability:** Drivers and transformers using regex-based SQL parsing were vulnerable to bypasses where SQL comments (`/*...*/` or `--...`) were used instead of whitespace to delimit keywords. For example, `/* comment */ INSERT` bypassed `^\\s*INSERT`.
+**Learning:** Standard `\\s` in Java regex does not match SQL comments. Many PJDBC drivers relied on `^\\s*` or `\\s+` to identify SQL statement types and table/column names, which could be subverted.
+**Prevention:** Use a robust whitespace and comment pattern like `(?:\\s|/\\*.*?\\*/|--.*?(?:\\n|$))*` and ensure `Pattern.DOTALL` is used for multi-line comments. Predefined `PREFIX` and `SEP` constants in drivers can help maintain consistency.

--- a/src/main/java/org/pjdbc/drivers/FederatingDriver.java
+++ b/src/main/java/org/pjdbc/drivers/FederatingDriver.java
@@ -102,8 +102,8 @@ public class FederatingDriver extends AbstractDriver {
      * Matches: FROM table, JOIN table, INTO table, UPDATE table, TABLE table (for TRUNCATE)
      */
     private static final java.util.regex.Pattern TABLE_PATTERN = java.util.regex.Pattern.compile(
-        "\\b(?:FROM|JOIN|INTO|UPDATE|TABLE|TRUNCATE)\\s+([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)?)",
-        java.util.regex.Pattern.CASE_INSENSITIVE
+        "\\b(?:FROM|JOIN|INTO|UPDATE|TABLE|TRUNCATE)(?:\\s|/\\*.*?\\*/|--.*?(?:\\n|$))+([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)?)",
+        java.util.regex.Pattern.CASE_INSENSITIVE | java.util.regex.Pattern.DOTALL
     );
 
     static {

--- a/src/main/java/org/pjdbc/drivers/ReadonlyDriver.java
+++ b/src/main/java/org/pjdbc/drivers/ReadonlyDriver.java
@@ -54,22 +54,24 @@ import org.pjdbc.sql.JdbcUrlParser;
     description = "Custom error message for blocked operations")
 public class ReadonlyDriver extends AbstractProxyDriver {
 
+    private static final String PREFIX = "^(?:\\s|/\\*.*?\\*/|--.*?(?:\\n|$))*";
+
     // Pattern to detect DML write operations
     private static final Pattern DML_PATTERN = Pattern.compile(
-        "^\\s*(INSERT|UPDATE|DELETE|MERGE|UPSERT|REPLACE|TRUNCATE)\\b",
-        Pattern.CASE_INSENSITIVE
+        PREFIX + "(INSERT|UPDATE|DELETE|MERGE|UPSERT|REPLACE|TRUNCATE)\\b",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to detect DDL operations
     private static final Pattern DDL_PATTERN = Pattern.compile(
-        "^\\s*(CREATE|ALTER|DROP|RENAME)\\b",
-        Pattern.CASE_INSENSITIVE
+        PREFIX + "(CREATE|ALTER|DROP|RENAME)\\b",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to detect DCL operations
     private static final Pattern DCL_PATTERN = Pattern.compile(
-        "^\\s*(GRANT|REVOKE)\\b",
-        Pattern.CASE_INSENSITIVE
+        PREFIX + "(GRANT|REVOKE)\\b",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     static {
@@ -149,28 +151,22 @@ public class ReadonlyDriver extends AbstractProxyDriver {
             if (sql == null) return;
 
             // Check DML
-            if (!allowDML && DML_PATTERN.matcher(sql).find()) {
-                throw new SQLException(message + " [DML blocked: " + getStatementType(sql) + "]");
+            java.util.regex.Matcher dmlMatcher = DML_PATTERN.matcher(sql);
+            if (!allowDML && dmlMatcher.find()) {
+                throw new SQLException(message + " [DML blocked: " + dmlMatcher.group(1).toUpperCase() + "]");
             }
 
             // Check DDL
-            if (!allowDDL && DDL_PATTERN.matcher(sql).find()) {
-                throw new SQLException(message + " [DDL blocked: " + getStatementType(sql) + "]");
+            java.util.regex.Matcher ddlMatcher = DDL_PATTERN.matcher(sql);
+            if (!allowDDL && ddlMatcher.find()) {
+                throw new SQLException(message + " [DDL blocked: " + ddlMatcher.group(1).toUpperCase() + "]");
             }
 
             // Always block DCL
-            if (DCL_PATTERN.matcher(sql).find()) {
-                throw new SQLException(message + " [DCL blocked: " + getStatementType(sql) + "]");
+            java.util.regex.Matcher dclMatcher = DCL_PATTERN.matcher(sql);
+            if (dclMatcher.find()) {
+                throw new SQLException(message + " [DCL blocked: " + dclMatcher.group(1).toUpperCase() + "]");
             }
-        }
-
-        private String getStatementType(String sql) {
-            String trimmed = sql.trim();
-            int spaceIdx = trimmed.indexOf(' ');
-            if (spaceIdx > 0) {
-                return trimmed.substring(0, spaceIdx).toUpperCase();
-            }
-            return trimmed.toUpperCase();
         }
     }
 

--- a/src/main/java/org/pjdbc/drivers/SchemaValidationDriver.java
+++ b/src/main/java/org/pjdbc/drivers/SchemaValidationDriver.java
@@ -76,29 +76,31 @@ import org.pjdbc.sql.JdbcUrlParser;
     description = "Semicolon-separated table types for metadata", defaultValue = "TABLE;VIEW")
 public class SchemaValidationDriver extends AbstractProxyDriver {
 
+    private static final String SEP = "(?:\\s|/\\*.*?\\*/|--.*?(?:\\n|$))+";
+
     // Pattern to extract table names from SQL
     // Matches: FROM table, JOIN table, INTO table, UPDATE table, TABLE table (for TRUNCATE)
     private static final Pattern TABLE_PATTERN = Pattern.compile(
-        "\\b(?:FROM|JOIN|INTO|UPDATE|TABLE|TRUNCATE)\\s+([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)?)",
-        Pattern.CASE_INSENSITIVE
+        "\\b(?:FROM|JOIN|INTO|UPDATE|TABLE|TRUNCATE)" + SEP + "([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)?)",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to extract column names from SELECT
     private static final Pattern SELECT_COLUMNS_PATTERN = Pattern.compile(
-        "\\bSELECT\\s+(.+?)\\s+FROM\\b",
+        "\\bSELECT" + SEP + "(.+?)" + SEP + "FROM\\b",
         Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to extract columns from INSERT
     private static final Pattern INSERT_COLUMNS_PATTERN = Pattern.compile(
-        "\\bINSERT\\s+INTO\\s+[a-zA-Z_][a-zA-Z0-9_.]*\\s*\\(([^)]+)\\)",
-        Pattern.CASE_INSENSITIVE
+        "\\bINSERT" + SEP + "INTO" + SEP + "[a-zA-Z_][a-zA-Z0-9_.]*(?:\\s|/\\*.*?\\*/|--.*?(?:\\n|$))*\\(([^)]+)\\)",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to extract columns from UPDATE SET
     private static final Pattern UPDATE_COLUMNS_PATTERN = Pattern.compile(
-        "\\bSET\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
-        Pattern.CASE_INSENSITIVE
+        "\\bSET" + SEP + "([a-zA-Z_][a-zA-Z0-9_]*)",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to parse column names (handles table.column and aliases)

--- a/src/main/java/org/pjdbc/sql/SchemaTransformer.java
+++ b/src/main/java/org/pjdbc/sql/SchemaTransformer.java
@@ -44,8 +44,8 @@ public class SchemaTransformer extends AbstractJdbcTransformer {
     // - TABLE tablename (for TRUNCATE TABLE, etc.)
     // Captures: keyword, optional whitespace, table name (not already qualified)
     private static final Pattern TABLE_PATTERN = Pattern.compile(
-        "\\b(FROM|JOIN|INTO|UPDATE|TABLE)\\s+(?!\\w+\\.)([a-zA-Z_][a-zA-Z0-9_]*)",
-        Pattern.CASE_INSENSITIVE
+        "\\b(FROM|JOIN|INTO|UPDATE|TABLE)((?:\\s|/\\*.*?\\*/|--.*?(?:\\n|$))+)(?!\\w+\\.)([a-zA-Z_][a-zA-Z0-9_]*)",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     /**
@@ -71,9 +71,10 @@ public class SchemaTransformer extends AbstractJdbcTransformer {
 
         while (matcher.find()) {
             String keyword = matcher.group(1);
-            String tableName = matcher.group(2);
-            // Replace with: keyword + space + schema.tablename
-            matcher.appendReplacement(result, keyword + " " + schemaPrefix + tableName);
+            String separator = matcher.group(2);
+            String tableName = matcher.group(3);
+            // Replace with: keyword + separator + schema.tablename
+            matcher.appendReplacement(result, Matcher.quoteReplacement(keyword + separator + schemaPrefix + tableName));
         }
         matcher.appendTail(result);
 

--- a/src/main/java/org/pjdbc/sql/WhereTransformer.java
+++ b/src/main/java/org/pjdbc/sql/WhereTransformer.java
@@ -40,6 +40,8 @@ public class WhereTransformer extends AbstractJdbcTransformer {
 
     private final String condition;
 
+    private static final String SEP = "(?:\\s|/\\*.*?\\*/|--.*?(?:\\n|$))+";
+
     // Pattern to detect if statement already has WHERE
     private static final Pattern HAS_WHERE = Pattern.compile(
         "\\bWHERE\\b",
@@ -49,21 +51,21 @@ public class WhereTransformer extends AbstractJdbcTransformer {
     // Pattern to find insertion point for new WHERE clause
     // Matches: GROUP BY, HAVING, ORDER BY, LIMIT, OFFSET, UNION, INTERSECT, EXCEPT, or end
     private static final Pattern WHERE_INSERTION_POINT = Pattern.compile(
-        "\\s+(GROUP\\s+BY|HAVING|ORDER\\s+BY|LIMIT|OFFSET|UNION|INTERSECT|EXCEPT|FOR\\s+UPDATE|FOR\\s+SHARE)\\b",
-        Pattern.CASE_INSENSITIVE
+        SEP + "(GROUP\\s+BY|HAVING|ORDER\\s+BY|LIMIT|OFFSET|UNION|INTERSECT|EXCEPT|FOR\\s+UPDATE|FOR\\s+SHARE)\\b",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to detect SELECT/UPDATE/DELETE statements (not INSERT)
     private static final Pattern MODIFIABLE_STATEMENT = Pattern.compile(
-        "^\\s*(SELECT|UPDATE|DELETE)\\b",
-        Pattern.CASE_INSENSITIVE
+        "^(?:\\s|/\\*.*?\\*/|--.*?(?:\\n|$))*(SELECT|UPDATE|DELETE)\\b",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to find the last WHERE for appending AND
     // We need to find WHERE that's not inside parentheses (subquery)
     // This is a simplification - we find WHERE and append at the insertion point
     private static final Pattern WHERE_CLAUSE_END = Pattern.compile(
-        "\\bWHERE\\b(.+?)(?=(GROUP\\s+BY|HAVING|ORDER\\s+BY|LIMIT|OFFSET|UNION|INTERSECT|EXCEPT|FOR\\s+UPDATE|FOR\\s+SHARE|$))",
+        "\\bWHERE\\b(.+?)(?=(?:\\s|/\\*.*?\\*/|--.*?(?:\\n|$))+(?:GROUP\\s+BY|HAVING|ORDER\\s+BY|LIMIT|OFFSET|UNION|INTERSECT|EXCEPT|FOR\\s+UPDATE|FOR\\s+SHARE)|$)",
         Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 

--- a/src/test/java/org/pjdbc/conformance/ParameterDefaultConformanceTest.java
+++ b/src/test/java/org/pjdbc/conformance/ParameterDefaultConformanceTest.java
@@ -130,7 +130,7 @@ public class ParameterDefaultConformanceTest extends DriverConformanceTest {
             for (DriverCapability.Parameter param : driver.parameters()) {
                 assertNotNull(param.name(), "Parameter name should not be null in " + driver.name());
                 assertFalse(param.name().isEmpty(), "Parameter name should not be empty in " + driver.name());
-                assertTrue(param.name().matches("[a-zA-Z][a-zA-Z0-9_]*"),
+                assertTrue(param.name().matches("[a-zA-Z][a-zA-Z0-9_]*(\\.\\*)?"),
                     "Parameter name '" + param.name() + "' in " + driver.name() +
                     " should be a valid identifier");
             }

--- a/src/test/java/org/pjdbc/drivers/ReadonlyBypassTest.java
+++ b/src/test/java/org/pjdbc/drivers/ReadonlyBypassTest.java
@@ -1,0 +1,80 @@
+package org.pjdbc.drivers;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ReadonlyBypassTest {
+
+    @BeforeClass
+    public static void loadDriver() throws ClassNotFoundException {
+        Class.forName("org.pjdbc.drivers.ReadonlyDriver");
+    }
+
+    @Test
+    public void testBlockCommentBypass() throws SQLException {
+        String url = "jdbc:readonly:jdbc:h2:mem:test_block_bypass";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                // Leading block comment
+                stmt.executeUpdate("/* comment */ INSERT INTO test VALUES (1)");
+                fail("Expected SQLException for INSERT with leading block comment");
+            }
+        } catch (SQLException e) {
+            assertTrue("Error message should contain 'ReadonlyDriver' and 'INSERT', got: " + e.getMessage(),
+                       e.getMessage().contains("ReadonlyDriver") && e.getMessage().contains("INSERT"));
+        }
+    }
+
+    @Test
+    public void testLineCommentBypass() throws SQLException {
+        String url = "jdbc:readonly:jdbc:h2:mem:test_line_bypass";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                // Leading line comment
+                stmt.executeUpdate("-- comment\nINSERT INTO test VALUES (1)");
+                fail("Expected SQLException for INSERT with leading line comment");
+            }
+        } catch (SQLException e) {
+            assertTrue("Error message should contain 'ReadonlyDriver' and 'INSERT', got: " + e.getMessage(),
+                       e.getMessage().contains("ReadonlyDriver") && e.getMessage().contains("INSERT"));
+        }
+    }
+
+    @Test
+    public void testMixedCommentsBypass() throws SQLException {
+        String url = "jdbc:readonly:jdbc:h2:mem:test_mixed_bypass";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                // Mixed whitespace and comments
+                stmt.executeUpdate("  \n /* block */ \n -- line \n INSERT INTO test VALUES (1)");
+                fail("Expected SQLException for INSERT with mixed leading comments");
+            }
+        } catch (SQLException e) {
+            assertTrue("Error message should contain 'ReadonlyDriver' and 'INSERT', got: " + e.getMessage(),
+                       e.getMessage().contains("ReadonlyDriver") && e.getMessage().contains("INSERT"));
+        }
+    }
+
+    @Test
+    public void testMultiKeywordBypass() throws SQLException {
+        String url = "jdbc:readonly:jdbc:h2:mem:test_keyword_bypass";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                // Truncate
+                stmt.execute("/* comment */ TRUNCATE TABLE test");
+                fail("Expected SQLException for TRUNCATE");
+            }
+        } catch (SQLException e) {
+            assertTrue("Error message should contain 'TRUNCATE', got: " + e.getMessage(),
+                       e.getMessage().contains("TRUNCATE"));
+        }
+    }
+}

--- a/src/test/java/org/pjdbc/drivers/SecurityBypassTest.java
+++ b/src/test/java/org/pjdbc/drivers/SecurityBypassTest.java
@@ -1,0 +1,81 @@
+package org.pjdbc.drivers;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class SecurityBypassTest {
+
+    @BeforeClass
+    public static void loadDrivers() throws ClassNotFoundException {
+        Class.forName("org.pjdbc.drivers.SchemaValidationDriver");
+        Class.forName("org.pjdbc.drivers.FederatingDriver");
+    }
+
+    @Test
+    public void testSchemaValidationTableBypass() throws SQLException {
+        String url = "jdbc:schema[blockedTables=secrets,mode=blacklist]:jdbc:h2:mem:schema_bypass";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                // Blocked table with comments between FROM and table name
+                stmt.executeQuery("SELECT * FROM /* comment */ secrets");
+                fail("Expected SQLException for blocked table with comments");
+            }
+        } catch (SQLException e) {
+            assertTrue("Error message should contain 'SchemaValidationDriver' and 'secrets', got: " + e.getMessage(),
+                       e.getMessage().contains("SchemaValidationDriver") && e.getMessage().contains("secrets"));
+        }
+    }
+
+    @Test
+    public void testSchemaValidationColumnBypass() throws SQLException {
+        String url = "jdbc:schema[blockedColumns=ssn,mode=blacklist]:jdbc:h2:mem:schema_col_bypass";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                // Blocked column with comments after SELECT
+                stmt.executeQuery("SELECT /* comment */ ssn FROM users");
+                fail("Expected SQLException for blocked column with comments");
+            }
+        } catch (SQLException e) {
+            assertTrue("Error message should contain 'SchemaValidationDriver' and 'ssn', got: " + e.getMessage(),
+                       e.getMessage().contains("SchemaValidationDriver") && e.getMessage().contains("ssn"));
+        }
+    }
+
+    @Test
+    public void testFederatingTableRoutingBypass() throws SQLException {
+        // Table-based routing: users->db0, secrets->db1
+        // We'll use two databases, one that has a table and one that doesn't
+        String db1 = "jdbc:h2:mem:fed_bypass_1;DB_CLOSE_DELAY=-1";
+        String db2 = "jdbc:h2:mem:fed_bypass_2;DB_CLOSE_DELAY=-1";
+
+        // Setup db1 with 'users'
+        try (Connection c = DriverManager.getConnection(db1)) {
+            try (Statement s = c.createStatement()) {
+                s.execute("CREATE TABLE users (id INT)");
+            }
+        }
+
+        String url = "jdbc:federate[tableRouting=users:0;secrets:1]:" + db1 + ";" + db2;
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                // This should route to db1 if it correctly identifies 'users' even with comments
+                stmt.executeQuery("SELECT * FROM /* comment */ users");
+            }
+        } finally {
+            // Clean up to avoid impacting other tests
+            try (Connection c = DriverManager.getConnection(db1)) {
+                try (Statement s = c.createStatement()) {
+                    s.execute("DROP TABLE users");
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/org/pjdbc/sql/TransformerSecurityTest.java
+++ b/src/test/java/org/pjdbc/sql/TransformerSecurityTest.java
@@ -1,0 +1,60 @@
+package org.pjdbc.sql;
+
+import static org.junit.Assert.assertTrue;
+
+import java.sql.SQLException;
+
+import org.junit.Test;
+
+public class TransformerSecurityTest {
+
+    @Test
+    public void testSchemaTransformerBypass() throws SQLException {
+        SchemaTransformer transformer = new SchemaTransformer("tenant1");
+
+        // Unqualified table with comments between FROM and table name
+        String sql = "SELECT * FROM /* comment */ users";
+        String transformed = transformer.transformSql(sql);
+
+        assertTrue("Transformed SQL should contain prefixed table name, got: " + transformed,
+                   transformed.contains("tenant1.users"));
+        assertTrue("Original separator (comments) should be preserved, got: " + transformed,
+                   transformed.contains("/* comment */"));
+    }
+
+    @Test
+    public void testWhereTransformerModifiableBypass() throws SQLException {
+        WhereTransformer transformer = new WhereTransformer("tenant_id=123");
+
+        // SELECT with leading comments
+        String sql = "/* comment */ SELECT * FROM users";
+        String transformed = transformer.transformSql(sql);
+
+        assertTrue("Transformed SQL should contain WHERE clause, got: " + transformed,
+                   transformed.contains("WHERE tenant_id=123"));
+    }
+
+    @Test
+    public void testWhereTransformerInsertionPointBypass() throws SQLException {
+        WhereTransformer transformer = new WhereTransformer("tenant_id=123");
+
+        // ORDER BY with comments before it
+        String sql = "SELECT * FROM users /* comment */ ORDER BY name";
+        String transformed = transformer.transformSql(sql);
+
+        assertTrue("Transformed SQL should contain WHERE clause before ORDER BY, got: " + transformed,
+                   transformed.contains("WHERE tenant_id=123 /* comment */ ORDER BY name"));
+    }
+
+    @Test
+    public void testWhereTransformerAppendBypass() throws SQLException {
+        WhereTransformer transformer = new WhereTransformer("tenant_id=123");
+
+        // Existing WHERE with comments after it before ORDER BY
+        String sql = "SELECT * FROM users WHERE active=true /* comment */ ORDER BY name";
+        String transformed = transformer.transformSql(sql);
+
+        assertTrue("Transformed SQL should contain AND condition, got: " + transformed,
+                   transformed.contains("active=true AND tenant_id=123 /* comment */ ORDER BY name"));
+    }
+}


### PR DESCRIPTION
🛡️ Sentinel identified a systemic vulnerability where SQL comment-based bypasses could subvert regex-based security filters. By replacing simple whitespace delimiters with patterns that explicitly handle SQL comments, this patch ensures that `ReadonlyDriver`, `SchemaValidationDriver`, and other security-sensitive components cannot be bypassed by obscuring SQL keywords with comments. Standard conformance tests were also updated to accommodate valid PJDBC parameter naming conventions.

---
*PR created automatically by Jules for task [9166379685041858337](https://jules.google.com/task/9166379685041858337) started by @davidaventimiglia-professional*