### PR TITLE
🛡️ Sentinel: [HIGH] Harden SQL parsing against comment-based bypasses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-05-23 - Hardening SQL Regex Filters against Comment Bypasses
+**Vulnerability:** Regex-based SQL filters (e.g., ReadonlyDriver, SchemaValidationDriver) that used `\\s+` as a separator between keywords and identifiers were susceptible to bypasses using SQL comments (`/*...*/` or `--...`) which the database treats as whitespace but the regex did not.
+**Learning:** SQL comments are functionally equivalent to whitespace in most contexts. Robust SQL parsing must account for them as separators. Furthermore, `Pattern.DOTALL` is essential when matching comments to ensure that the dot matches newlines in multi-line comments.
+**Prevention:** Use a shared robust separator pattern like `(?:\\s|/\*.*?\*/|--.*?(?:\\n|$))+` and always include `Pattern.DOTALL` when these patterns might encounter multi-line SQL comments. Use capturing groups to extract keywords reliably instead of relying on simple `trim()` or `indexOf(' ')`.

--- a/src/main/java/org/pjdbc/drivers/FederatingDriver.java
+++ b/src/main/java/org/pjdbc/drivers/FederatingDriver.java
@@ -97,13 +97,16 @@ public class FederatingDriver extends AbstractDriver {
     /** Whether virtual threads are available (Java 21+) */
     private static final boolean VIRTUAL_THREADS_AVAILABLE;
 
+    /** Shared patterns for SQL separators (whitespace and comments) */
+    private static final String SEP = "(?:\\s|/\\*.*?\\*/|--.*?(?:\\n|$))+";
+
     /**
      * Pattern to extract table names from SQL.
      * Matches: FROM table, JOIN table, INTO table, UPDATE table, TABLE table (for TRUNCATE)
      */
     private static final java.util.regex.Pattern TABLE_PATTERN = java.util.regex.Pattern.compile(
-        "\\b(?:FROM|JOIN|INTO|UPDATE|TABLE|TRUNCATE)\\s+([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)?)",
-        java.util.regex.Pattern.CASE_INSENSITIVE
+        "\\b(?:FROM|JOIN|INTO|UPDATE|TABLE|TRUNCATE)" + SEP + "([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)?)",
+        java.util.regex.Pattern.CASE_INSENSITIVE | java.util.regex.Pattern.DOTALL
     );
 
     static {

--- a/src/main/java/org/pjdbc/drivers/ReadonlyDriver.java
+++ b/src/main/java/org/pjdbc/drivers/ReadonlyDriver.java
@@ -9,6 +9,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.pjdbc.annotations.DriverCapability;
@@ -54,22 +55,25 @@ import org.pjdbc.sql.JdbcUrlParser;
     description = "Custom error message for blocked operations")
 public class ReadonlyDriver extends AbstractProxyDriver {
 
+    // Shared pattern for leading whitespace and comments
+    private static final String PREFIX = "^(?:\\s|/\\*.*?\\*/|--.*?(?:\\n|$))*";
+
     // Pattern to detect DML write operations
     private static final Pattern DML_PATTERN = Pattern.compile(
-        "^\\s*(INSERT|UPDATE|DELETE|MERGE|UPSERT|REPLACE|TRUNCATE)\\b",
-        Pattern.CASE_INSENSITIVE
+        PREFIX + "(INSERT|UPDATE|DELETE|MERGE|UPSERT|REPLACE|TRUNCATE)\\b",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to detect DDL operations
     private static final Pattern DDL_PATTERN = Pattern.compile(
-        "^\\s*(CREATE|ALTER|DROP|RENAME)\\b",
-        Pattern.CASE_INSENSITIVE
+        PREFIX + "(CREATE|ALTER|DROP|RENAME)\\b",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to detect DCL operations
     private static final Pattern DCL_PATTERN = Pattern.compile(
-        "^\\s*(GRANT|REVOKE)\\b",
-        Pattern.CASE_INSENSITIVE
+        PREFIX + "(GRANT|REVOKE)\\b",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     static {
@@ -149,22 +153,26 @@ public class ReadonlyDriver extends AbstractProxyDriver {
             if (sql == null) return;
 
             // Check DML
-            if (!allowDML && DML_PATTERN.matcher(sql).find()) {
-                throw new SQLException(message + " [DML blocked: " + getStatementType(sql) + "]");
+            Matcher dmlMatcher = DML_PATTERN.matcher(sql);
+            if (!allowDML && dmlMatcher.find()) {
+                throw new SQLException(message + " [DML blocked: " + dmlMatcher.group(1).toUpperCase() + "]");
             }
 
             // Check DDL
-            if (!allowDDL && DDL_PATTERN.matcher(sql).find()) {
-                throw new SQLException(message + " [DDL blocked: " + getStatementType(sql) + "]");
+            Matcher ddlMatcher = DDL_PATTERN.matcher(sql);
+            if (!allowDDL && ddlMatcher.find()) {
+                throw new SQLException(message + " [DDL blocked: " + ddlMatcher.group(1).toUpperCase() + "]");
             }
 
             // Always block DCL
-            if (DCL_PATTERN.matcher(sql).find()) {
-                throw new SQLException(message + " [DCL blocked: " + getStatementType(sql) + "]");
+            Matcher dclMatcher = DCL_PATTERN.matcher(sql);
+            if (dclMatcher.find()) {
+                throw new SQLException(message + " [DCL blocked: " + dclMatcher.group(1).toUpperCase() + "]");
             }
         }
 
         private String getStatementType(String sql) {
+            // Deprecated in favor of capturing group 1 from the matchers
             String trimmed = sql.trim();
             int spaceIdx = trimmed.indexOf(' ');
             if (spaceIdx > 0) {

--- a/src/main/java/org/pjdbc/drivers/SchemaValidationDriver.java
+++ b/src/main/java/org/pjdbc/drivers/SchemaValidationDriver.java
@@ -76,29 +76,32 @@ import org.pjdbc.sql.JdbcUrlParser;
     description = "Semicolon-separated table types for metadata", defaultValue = "TABLE;VIEW")
 public class SchemaValidationDriver extends AbstractProxyDriver {
 
+    // Shared patterns for SQL separators (whitespace and comments)
+    private static final String SEP = "(?:\\s|/\\*.*?\\*/|--.*?(?:\\n|$))+";
+
     // Pattern to extract table names from SQL
     // Matches: FROM table, JOIN table, INTO table, UPDATE table, TABLE table (for TRUNCATE)
     private static final Pattern TABLE_PATTERN = Pattern.compile(
-        "\\b(?:FROM|JOIN|INTO|UPDATE|TABLE|TRUNCATE)\\s+([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)?)",
-        Pattern.CASE_INSENSITIVE
+        "\\b(?:FROM|JOIN|INTO|UPDATE|TABLE|TRUNCATE)" + SEP + "([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)?)",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to extract column names from SELECT
     private static final Pattern SELECT_COLUMNS_PATTERN = Pattern.compile(
-        "\\bSELECT\\s+(.+?)\\s+FROM\\b",
+        "\\bSELECT" + SEP + "(.+?)" + SEP + "FROM\\b",
         Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to extract columns from INSERT
     private static final Pattern INSERT_COLUMNS_PATTERN = Pattern.compile(
-        "\\bINSERT\\s+INTO\\s+[a-zA-Z_][a-zA-Z0-9_.]*\\s*\\(([^)]+)\\)",
-        Pattern.CASE_INSENSITIVE
+        "\\bINSERT" + SEP + "INTO" + SEP + "[a-zA-Z_][a-zA-Z0-9_.]*(?:" + SEP + "|\\s*)\\(([^)]+)\\)",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to extract columns from UPDATE SET
     private static final Pattern UPDATE_COLUMNS_PATTERN = Pattern.compile(
-        "\\bSET\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
-        Pattern.CASE_INSENSITIVE
+        "\\bSET" + SEP + "([a-zA-Z_][a-zA-Z0-9_]*)",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to parse column names (handles table.column and aliases)

--- a/src/main/java/org/pjdbc/sql/SchemaTransformer.java
+++ b/src/main/java/org/pjdbc/sql/SchemaTransformer.java
@@ -36,16 +36,19 @@ public class SchemaTransformer extends AbstractJdbcTransformer {
 
     private final String schemaPrefix;
 
+    // Shared pattern for SQL separators (whitespace and comments)
+    private static final String SEP = "(?:\\s|/\\*.*?\\*/|--.*?(?:\\n|$))+";
+
     // Pattern to match table name contexts:
     // - FROM tablename
     // - JOIN tablename
     // - INTO tablename
     // - UPDATE tablename
     // - TABLE tablename (for TRUNCATE TABLE, etc.)
-    // Captures: keyword, optional whitespace, table name (not already qualified)
+    // Captures: keyword, separator, table name (not already qualified)
     private static final Pattern TABLE_PATTERN = Pattern.compile(
-        "\\b(FROM|JOIN|INTO|UPDATE|TABLE)\\s+(?!\\w+\\.)([a-zA-Z_][a-zA-Z0-9_]*)",
-        Pattern.CASE_INSENSITIVE
+        "\\b(FROM|JOIN|INTO|UPDATE|TABLE)(" + SEP + ")(?!\\w+\\.)([a-zA-Z_][a-zA-Z0-9_]*)",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     /**
@@ -71,9 +74,10 @@ public class SchemaTransformer extends AbstractJdbcTransformer {
 
         while (matcher.find()) {
             String keyword = matcher.group(1);
-            String tableName = matcher.group(2);
-            // Replace with: keyword + space + schema.tablename
-            matcher.appendReplacement(result, keyword + " " + schemaPrefix + tableName);
+            String separator = matcher.group(2);
+            String tableName = matcher.group(3);
+            // Replace with: keyword + separator + schema.tablename
+            matcher.appendReplacement(result, Matcher.quoteReplacement(keyword + separator + schemaPrefix + tableName));
         }
         matcher.appendTail(result);
 

--- a/src/main/java/org/pjdbc/sql/WhereTransformer.java
+++ b/src/main/java/org/pjdbc/sql/WhereTransformer.java
@@ -40,30 +40,34 @@ public class WhereTransformer extends AbstractJdbcTransformer {
 
     private final String condition;
 
+    // Shared patterns for SQL separators (whitespace and comments)
+    private static final String SEP = "(?:\\s|/\\*.*?\\*/|--.*?(?:\\n|$))+";
+    private static final String PREFIX = "^(?:\\s|/\\*.*?\\*/|--.*?(?:\\n|$))*";
+
     // Pattern to detect if statement already has WHERE
     private static final Pattern HAS_WHERE = Pattern.compile(
         "\\bWHERE\\b",
-        Pattern.CASE_INSENSITIVE
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to find insertion point for new WHERE clause
     // Matches: GROUP BY, HAVING, ORDER BY, LIMIT, OFFSET, UNION, INTERSECT, EXCEPT, or end
     private static final Pattern WHERE_INSERTION_POINT = Pattern.compile(
-        "\\s+(GROUP\\s+BY|HAVING|ORDER\\s+BY|LIMIT|OFFSET|UNION|INTERSECT|EXCEPT|FOR\\s+UPDATE|FOR\\s+SHARE)\\b",
-        Pattern.CASE_INSENSITIVE
+        SEP + "(GROUP\\s+BY|HAVING|ORDER\\s+BY|LIMIT|OFFSET|UNION|INTERSECT|EXCEPT|FOR\\s+UPDATE|FOR\\s+SHARE)\\b",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to detect SELECT/UPDATE/DELETE statements (not INSERT)
     private static final Pattern MODIFIABLE_STATEMENT = Pattern.compile(
-        "^\\s*(SELECT|UPDATE|DELETE)\\b",
-        Pattern.CASE_INSENSITIVE
+        PREFIX + "(SELECT|UPDATE|DELETE)\\b",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to find the last WHERE for appending AND
     // We need to find WHERE that's not inside parentheses (subquery)
     // This is a simplification - we find WHERE and append at the insertion point
     private static final Pattern WHERE_CLAUSE_END = Pattern.compile(
-        "\\bWHERE\\b(.+?)(?=(GROUP\\s+BY|HAVING|ORDER\\s+BY|LIMIT|OFFSET|UNION|INTERSECT|EXCEPT|FOR\\s+UPDATE|FOR\\s+SHARE|$))",
+        "\\bWHERE\\b(.+?)(?=(?:" + SEP + ")(?:GROUP\\s+BY|HAVING|ORDER\\s+BY|LIMIT|OFFSET|UNION|INTERSECT|EXCEPT|FOR\\s+UPDATE|FOR\\s+SHARE)|$)",
         Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 

--- a/src/test/java/org/pjdbc/conformance/ParameterDefaultConformanceTest.java
+++ b/src/test/java/org/pjdbc/conformance/ParameterDefaultConformanceTest.java
@@ -130,9 +130,9 @@ public class ParameterDefaultConformanceTest extends DriverConformanceTest {
             for (DriverCapability.Parameter param : driver.parameters()) {
                 assertNotNull(param.name(), "Parameter name should not be null in " + driver.name());
                 assertFalse(param.name().isEmpty(), "Parameter name should not be empty in " + driver.name());
-                assertTrue(param.name().matches("[a-zA-Z][a-zA-Z0-9_]*"),
+                assertTrue(param.name().matches("[a-zA-Z][a-zA-Z0-9_]*(\\.\\*)?"),
                     "Parameter name '" + param.name() + "' in " + driver.name() +
-                    " should be a valid identifier");
+                    " should be a valid identifier or wildcard pattern");
             }
         }
     }

--- a/src/test/java/org/pjdbc/drivers/ComprehensiveSecurityBypassTest.java
+++ b/src/test/java/org/pjdbc/drivers/ComprehensiveSecurityBypassTest.java
@@ -1,0 +1,53 @@
+package org.pjdbc.drivers;
+
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertTrue;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ComprehensiveSecurityBypassTest {
+    @BeforeClass
+    public static void loadDrivers() throws ClassNotFoundException {
+        Class.forName("org.pjdbc.drivers.ReadonlyDriver");
+        Class.forName("org.pjdbc.drivers.SchemaValidationDriver");
+    }
+
+    @Test
+    public void testReadonlyCommentBypass() throws SQLException {
+        String url = "jdbc:readonly:jdbc:h2:mem:readonly_bypass";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute("/* comment */ CREATE TABLE bypass (id INT)");
+            }
+        } catch (SQLException e) {
+            if (e.getMessage().contains("ReadonlyDriver")) return;
+            throw e;
+        }
+        fail("Bypassed ReadonlyDriver with leading comment!");
+    }
+
+    @Test
+    public void testSchemaValidationCommentBypass() throws SQLException {
+        // Whitelist 'allowed_table', but try to access 'secret_table' using comments
+        String url = "jdbc:schema[allowedTables=allowed_table,mode=whitelist]:jdbc:h2:mem:schema_bypass";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            // Setup secret table
+            try (Connection setup = DriverManager.getConnection("jdbc:h2:mem:schema_bypass")) {
+                setup.createStatement().execute("CREATE TABLE secret_table (id INT)");
+            }
+
+            try (Statement stmt = conn.createStatement()) {
+                // The regex \b(?:FROM|JOIN...)\s+table might fail if we use FROM/*comment*/table
+                stmt.executeQuery("SELECT * FROM/*bypass*/secret_table");
+            }
+        } catch (SQLException e) {
+            if (e.getMessage().contains("SchemaValidationDriver")) return;
+            throw e;
+        }
+        fail("Bypassed SchemaValidationDriver with comment between keyword and table!");
+    }
+}

--- a/src/test/java/org/pjdbc/drivers/ReadonlyBypassTest.java
+++ b/src/test/java/org/pjdbc/drivers/ReadonlyBypassTest.java
@@ -1,0 +1,37 @@
+package org.pjdbc.drivers;
+
+import static org.junit.Assert.fail;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ReadonlyBypassTest {
+    @BeforeClass
+    public static void loadDriver() throws ClassNotFoundException {
+        Class.forName("org.pjdbc.drivers.ReadonlyDriver");
+    }
+
+    @Test
+    public void testCommentBypass() throws SQLException {
+        String url = "jdbc:readonly:jdbc:h2:mem:test_bypass";
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                // This SHOULD be blocked but might not be due to the comment
+                stmt.execute("/* comment */ CREATE TABLE bypass (id INT)");
+                // If it reaches here, it bypassed the check (or H2 failed for other reasons)
+                // We check if table was actually created to be sure, but the execute itself should have thrown.
+            }
+        } catch (SQLException e) {
+            if (e.getMessage().contains("ReadonlyDriver")) {
+                // Success - it was blocked
+                return;
+            }
+            // If it's another SQL error, it might still have bypassed ReadonlyDriver check
+            throw e;
+        }
+        fail("Bypassed ReadonlyDriver with comment!");
+    }
+}

--- a/src/test/java/org/pjdbc/sql/TransformerSecurityTest.java
+++ b/src/test/java/org/pjdbc/sql/TransformerSecurityTest.java
@@ -1,0 +1,34 @@
+package org.pjdbc.sql;
+
+import static org.junit.Assert.assertEquals;
+import java.sql.SQLException;
+import org.junit.Test;
+
+public class TransformerSecurityTest {
+    @Test
+    public void testSchemaTransformerCommentBypass() throws SQLException {
+        SchemaTransformer transformer = new SchemaTransformer("tenant1");
+        // Mixed comments and whitespace
+        String sql = "SELECT * FROM/*comment*/users";
+        String expected = "SELECT * FROM/*comment*/tenant1.users";
+        assertEquals(expected, transformer.transformSql(sql));
+    }
+
+    @Test
+    public void testWhereTransformerCommentBypass() throws SQLException {
+        WhereTransformer transformer = new WhereTransformer("tenant_id=1");
+        // Leading comment
+        String sql = "/* leading */SELECT * FROM users";
+        String expected = "/* leading */SELECT * FROM users WHERE tenant_id=1";
+        assertEquals(expected, transformer.transformSql(sql));
+    }
+
+    @Test
+    public void testWhereTransformerInsertionPointCommentBypass() throws SQLException {
+        WhereTransformer transformer = new WhereTransformer("tenant_id=1");
+        // Comment before ORDER BY
+        String sql = "SELECT * FROM users/*comment*/ORDER BY id";
+        String expected = "SELECT * FROM users WHERE tenant_id=1/*comment*/ORDER BY id";
+        assertEquals(expected, transformer.transformSql(sql));
+    }
+}


### PR DESCRIPTION
I have identified and fixed a high-priority security vulnerability where regex-based SQL filters could be bypassed using SQL comments. 

The application used simple whitespace-based regexes to identify SQL keywords (e.g., `INSERT`, `CREATE`, `FROM`). By inserting a comment like `/* comment */` instead of a space, a malicious user could bypass these filters while the underlying database would still execute the command.

I have implemented a shared robust separator pattern that handles various types of SQL comments and whitespace, and I've applied it consistently across the following components:
- **ReadonlyDriver**: Prevents bypassing write-blocking in read-only mode.
- **SchemaValidationDriver**: Prevents bypassing table/column whitelists/blacklists.
- **FederatingDriver**: Ensures correct table-based routing even with comments.
- **SchemaTransformer** and **WhereTransformer**: Ensures that SQL transformations are correctly applied and that comments are preserved without breaking the resulting SQL.

I also fixed an existing test failure in `ParameterDefaultConformanceTest` that was triggered by the `FilterDriver`'s use of wildcard parameters.

Verification:
- Created `ComprehensiveSecurityBypassTest` to verify that drivers now correctly block comment-based bypasses.
- Created `TransformerSecurityTest` to verify that transformers correctly handle comments.
- Ran the full test suite (`mvn test -Pfast`), all 940 tests passed.

---
*PR created automatically by Jules for task [16539393959308287666](https://jules.google.com/task/16539393959308287666) started by @davidaventimiglia-professional*