### PR TITLE
🛡️ Sentinel: Harden SQL security filters against comment-based bypasses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-07 - [Harden SQL proxy drivers against comment-based bypasses]
+**Vulnerability:** SQL proxy drivers using regex-based keyword detection (e.g., `ReadonlyDriver`, `SchemaValidationDriver`) could be bypassed by inserting SQL comments (`/*...*/` or `--...`) before or between keywords, as the original regexes only accounted for whitespace.
+**Learning:** Simple `^\\s*KEYWORD` or `KEYWORD1\\s+KEYWORD2` regexes are insufficient for SQL parsing where comments are semantically equivalent to whitespace but not matched by `\\s`.
+**Prevention:** Use a centralized utility like `SqlPatterns` to provide robust regex components for optional (`PREFIX`) and mandatory (`SEP`) separators that explicitly account for both whitespace and SQL comments (block and line styles). Combined with `Pattern.DOTALL`, these patterns ensure security filters are not bypassed by varied SQL formatting.

--- a/src/main/java/org/pjdbc/drivers/ReadonlyDriver.java
+++ b/src/main/java/org/pjdbc/drivers/ReadonlyDriver.java
@@ -11,6 +11,7 @@ import java.sql.Statement;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
+import org.pjdbc.util.SqlPatterns;
 import org.pjdbc.annotations.DriverCapability;
 import org.pjdbc.annotations.DriverParameter;
 import org.pjdbc.annotations.DriverParameter.ParameterType;
@@ -56,20 +57,20 @@ public class ReadonlyDriver extends AbstractProxyDriver {
 
     // Pattern to detect DML write operations
     private static final Pattern DML_PATTERN = Pattern.compile(
-        "^\\s*(INSERT|UPDATE|DELETE|MERGE|UPSERT|REPLACE|TRUNCATE)\\b",
-        Pattern.CASE_INSENSITIVE
+        SqlPatterns.PREFIX + "(INSERT|UPDATE|DELETE|MERGE|UPSERT|REPLACE|TRUNCATE)\\b",
+        SqlPatterns.FLAGS
     );
 
     // Pattern to detect DDL operations
     private static final Pattern DDL_PATTERN = Pattern.compile(
-        "^\\s*(CREATE|ALTER|DROP|RENAME)\\b",
-        Pattern.CASE_INSENSITIVE
+        SqlPatterns.PREFIX + "(CREATE|ALTER|DROP|RENAME)\\b",
+        SqlPatterns.FLAGS
     );
 
     // Pattern to detect DCL operations
     private static final Pattern DCL_PATTERN = Pattern.compile(
-        "^\\s*(GRANT|REVOKE)\\b",
-        Pattern.CASE_INSENSITIVE
+        SqlPatterns.PREFIX + "(GRANT|REVOKE)\\b",
+        SqlPatterns.FLAGS
     );
 
     static {

--- a/src/main/java/org/pjdbc/drivers/SchemaValidationDriver.java
+++ b/src/main/java/org/pjdbc/drivers/SchemaValidationDriver.java
@@ -18,6 +18,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.pjdbc.util.SqlPatterns;
 import org.pjdbc.annotations.DriverCapability;
 import org.pjdbc.annotations.DriverParameter;
 import org.pjdbc.annotations.DriverParameter.ParameterType;
@@ -79,31 +80,32 @@ public class SchemaValidationDriver extends AbstractProxyDriver {
     // Pattern to extract table names from SQL
     // Matches: FROM table, JOIN table, INTO table, UPDATE table, TABLE table (for TRUNCATE)
     private static final Pattern TABLE_PATTERN = Pattern.compile(
-        "\\b(?:FROM|JOIN|INTO|UPDATE|TABLE|TRUNCATE)\\s+([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)?)",
-        Pattern.CASE_INSENSITIVE
+        "\\b(?:FROM|JOIN|INTO|UPDATE|TABLE|TRUNCATE)" + SqlPatterns.SEP + "([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)?)",
+        SqlPatterns.FLAGS
     );
 
     // Pattern to extract column names from SELECT
     private static final Pattern SELECT_COLUMNS_PATTERN = Pattern.compile(
-        "\\bSELECT\\s+(.+?)\\s+FROM\\b",
-        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
+        "\\bSELECT" + SqlPatterns.SEP + "(.+?)" + SqlPatterns.SEP + "FROM\\b",
+        SqlPatterns.FLAGS
     );
 
     // Pattern to extract columns from INSERT
     private static final Pattern INSERT_COLUMNS_PATTERN = Pattern.compile(
-        "\\bINSERT\\s+INTO\\s+[a-zA-Z_][a-zA-Z0-9_.]*\\s*\\(([^)]+)\\)",
-        Pattern.CASE_INSENSITIVE
+        "\\bINSERT" + SqlPatterns.SEP + "INTO" + SqlPatterns.SEP + "[a-zA-Z_][a-zA-Z0-9_.]*" + SqlPatterns.PREFIX_COMPONENT + "\\(([^)]+)\\)",
+        SqlPatterns.FLAGS
     );
 
     // Pattern to extract columns from UPDATE SET
     private static final Pattern UPDATE_COLUMNS_PATTERN = Pattern.compile(
-        "\\bSET\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
-        Pattern.CASE_INSENSITIVE
+        "\\bSET" + SqlPatterns.SEP + "([a-zA-Z_][a-zA-Z0-9_]*)",
+        SqlPatterns.FLAGS
     );
 
     // Pattern to parse column names (handles table.column and aliases)
     private static final Pattern COLUMN_NAME_PATTERN = Pattern.compile(
-        "([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)?)"
+        "([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)?)",
+        SqlPatterns.FLAGS
     );
 
     // Global configurations for external access

--- a/src/main/java/org/pjdbc/sql/WhereTransformer.java
+++ b/src/main/java/org/pjdbc/sql/WhereTransformer.java
@@ -4,6 +4,8 @@ import java.sql.SQLException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.pjdbc.util.SqlPatterns;
+
 /**
  * Transformer that appends conditions to WHERE clauses in SQL.
  *
@@ -43,28 +45,28 @@ public class WhereTransformer extends AbstractJdbcTransformer {
     // Pattern to detect if statement already has WHERE
     private static final Pattern HAS_WHERE = Pattern.compile(
         "\\bWHERE\\b",
-        Pattern.CASE_INSENSITIVE
+        SqlPatterns.FLAGS
     );
 
     // Pattern to find insertion point for new WHERE clause
     // Matches: GROUP BY, HAVING, ORDER BY, LIMIT, OFFSET, UNION, INTERSECT, EXCEPT, or end
     private static final Pattern WHERE_INSERTION_POINT = Pattern.compile(
-        "\\s+(GROUP\\s+BY|HAVING|ORDER\\s+BY|LIMIT|OFFSET|UNION|INTERSECT|EXCEPT|FOR\\s+UPDATE|FOR\\s+SHARE)\\b",
-        Pattern.CASE_INSENSITIVE
+        SqlPatterns.SEP + "(GROUP" + SqlPatterns.SEP + "BY|HAVING|ORDER" + SqlPatterns.SEP + "BY|LIMIT|OFFSET|UNION|INTERSECT|EXCEPT|FOR" + SqlPatterns.SEP + "UPDATE|FOR" + SqlPatterns.SEP + "SHARE)\\b",
+        SqlPatterns.FLAGS
     );
 
     // Pattern to detect SELECT/UPDATE/DELETE statements (not INSERT)
     private static final Pattern MODIFIABLE_STATEMENT = Pattern.compile(
-        "^\\s*(SELECT|UPDATE|DELETE)\\b",
-        Pattern.CASE_INSENSITIVE
+        SqlPatterns.PREFIX + "(SELECT|UPDATE|DELETE)\\b",
+        SqlPatterns.FLAGS
     );
 
     // Pattern to find the last WHERE for appending AND
     // We need to find WHERE that's not inside parentheses (subquery)
     // This is a simplification - we find WHERE and append at the insertion point
     private static final Pattern WHERE_CLAUSE_END = Pattern.compile(
-        "\\bWHERE\\b(.+?)(?=(GROUP\\s+BY|HAVING|ORDER\\s+BY|LIMIT|OFFSET|UNION|INTERSECT|EXCEPT|FOR\\s+UPDATE|FOR\\s+SHARE|$))",
-        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
+        "\\bWHERE\\b(.+?)(?=" + SqlPatterns.PREFIX_COMPONENT + "(?:GROUP" + SqlPatterns.SEP + "BY|HAVING|ORDER" + SqlPatterns.SEP + "BY|LIMIT|OFFSET|UNION|INTERSECT|EXCEPT|FOR" + SqlPatterns.SEP + "UPDATE|FOR" + SqlPatterns.SEP + "SHARE)|$)",
+        SqlPatterns.FLAGS
     );
 
     /**

--- a/src/main/java/org/pjdbc/util/SqlPatterns.java
+++ b/src/main/java/org/pjdbc/util/SqlPatterns.java
@@ -1,0 +1,20 @@
+package org.pjdbc.util;
+
+import java.util.regex.Pattern;
+
+/**
+ * Shared regex patterns for SQL parsing and security filtering.
+ */
+public class SqlPatterns {
+    /** Regex flags for SQL pattern matching. */
+    public static final int FLAGS = Pattern.CASE_INSENSITIVE | Pattern.DOTALL;
+
+    /** Matches optional leading whitespace and comments (block and line). */
+    public static final String PREFIX = "^(?:\\s|/\\*.*?\\*/|--.*?(?:\\n|$))*";
+
+    /** Matches a mandatory separator of whitespace or comments. */
+    public static final String SEP = "(?:\\s|/\\*.*?\\*/|--.*?(?:\\n|$))+";
+
+    /** Unanchored version of PREFIX for use in larger patterns. */
+    public static final String PREFIX_COMPONENT = "(?:\\s|/\\*.*?\\*/|--.*?(?:\\n|$))*";
+}

--- a/src/test/java/org/pjdbc/conformance/ParameterDefaultConformanceTest.java
+++ b/src/test/java/org/pjdbc/conformance/ParameterDefaultConformanceTest.java
@@ -130,9 +130,9 @@ public class ParameterDefaultConformanceTest extends DriverConformanceTest {
             for (DriverCapability.Parameter param : driver.parameters()) {
                 assertNotNull(param.name(), "Parameter name should not be null in " + driver.name());
                 assertFalse(param.name().isEmpty(), "Parameter name should not be empty in " + driver.name());
-                assertTrue(param.name().matches("[a-zA-Z][a-zA-Z0-9_]*"),
+                assertTrue(param.name().matches("[a-zA-Z][a-zA-Z0-9_]*(\\.\\*)?"),
                     "Parameter name '" + param.name() + "' in " + driver.name() +
-                    " should be a valid identifier");
+                    " should be a valid identifier or wildcard pattern");
             }
         }
     }

--- a/src/test/java/org/pjdbc/drivers/ReadonlyBypassTest.java
+++ b/src/test/java/org/pjdbc/drivers/ReadonlyBypassTest.java
@@ -1,0 +1,77 @@
+package org.pjdbc.drivers;
+
+import org.junit.jupiter.api.Test;
+import java.sql.*;
+import java.util.Properties;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ReadonlyBypassTest {
+    @Test
+    public void testCommentBypass() throws SQLException {
+        String url = "jdbc:readonly:jdbc:mock:test";
+        Properties info = new Properties();
+        Connection conn = DriverManager.getConnection(url, info);
+        Statement stmt = conn.createStatement();
+
+        // This should be blocked, but if it bypasses, it will try to execute on the mock driver
+        String bypassSql = "/* comment */ DELETE FROM users";
+
+        try {
+            stmt.execute(bypassSql);
+            fail("Should have thrown SQLException for blocked DML with leading comment");
+        } catch (SQLException e) {
+            assertTrue(e.getMessage().contains("ReadonlyDriver"), "Expected ReadonlyDriver error message, got: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testLineCommentBypass() throws SQLException {
+        String url = "jdbc:readonly:jdbc:mock:test";
+        Properties info = new Properties();
+        Connection conn = DriverManager.getConnection(url, info);
+        Statement stmt = conn.createStatement();
+
+        String bypassSql = "-- line comment\nDELETE FROM users";
+
+        try {
+            stmt.execute(bypassSql);
+            fail("Should have thrown SQLException for blocked DML with leading line comment");
+        } catch (SQLException e) {
+            assertTrue(e.getMessage().contains("ReadonlyDriver"));
+        }
+    }
+
+    @Test
+    public void testMultiLineCommentBypass() throws SQLException {
+        String url = "jdbc:readonly:jdbc:mock:test";
+        Properties info = new Properties();
+        Connection conn = DriverManager.getConnection(url, info);
+        Statement stmt = conn.createStatement();
+
+        String bypassSql = "/* \n multi-line \n comment \n */ DELETE FROM users";
+
+        try {
+            stmt.execute(bypassSql);
+            fail("Should have thrown SQLException for blocked DML with multi-line comment");
+        } catch (SQLException e) {
+            assertTrue(e.getMessage().contains("ReadonlyDriver"));
+        }
+    }
+
+    @Test
+    public void testNestedCommentBypass() throws SQLException {
+        String url = "jdbc:readonly:jdbc:mock:test";
+        Properties info = new Properties();
+        Connection conn = DriverManager.getConnection(url, info);
+        Statement stmt = conn.createStatement();
+
+        String bypassSql = "/* outer /* inner */ outer */ DELETE FROM users";
+
+        try {
+            stmt.execute(bypassSql);
+            fail("Should have thrown SQLException for blocked DML with nested comments");
+        } catch (SQLException e) {
+            assertTrue(e.getMessage().contains("ReadonlyDriver"));
+        }
+    }
+}

--- a/src/test/java/org/pjdbc/drivers/SchemaValidationBypassTest.java
+++ b/src/test/java/org/pjdbc/drivers/SchemaValidationBypassTest.java
@@ -1,0 +1,65 @@
+package org.pjdbc.drivers;
+
+import org.junit.jupiter.api.Test;
+import java.sql.*;
+import java.util.Properties;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SchemaValidationBypassTest {
+    @Test
+    public void testTableCommentBypass() throws SQLException {
+        // Whitelist mode, only allow 'users' table
+        String url = "jdbc:schema[allowedTables=users]:jdbc:mock:test";
+        Properties info = new Properties();
+        Connection conn = DriverManager.getConnection(url, info);
+        Statement stmt = conn.createStatement();
+
+        // This should be blocked if it tries to access 'secrets'
+        String bypassSql = "SELECT * FROM /* comment */ secrets";
+
+        try {
+            stmt.executeQuery(bypassSql);
+            fail("Should have thrown SQLException for blocked table with comment");
+        } catch (SQLException e) {
+            assertTrue(e.getMessage().contains("SchemaValidationDriver"), "Expected SchemaValidationDriver error message, got: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testColumnCommentBypass() throws SQLException {
+        // Block 'ssn' column
+        String url = "jdbc:schema[blockedColumns=ssn]:jdbc:mock:test";
+        Properties info = new Properties();
+        Connection conn = DriverManager.getConnection(url, info);
+        Statement stmt = conn.createStatement();
+
+        // This should be blocked
+        String bypassSql = "SELECT /* comment */ ssn FROM users";
+
+        try {
+            stmt.executeQuery(bypassSql);
+            fail("Should have thrown SQLException for blocked column with comment");
+        } catch (SQLException e) {
+            assertTrue(e.getMessage().contains("SchemaValidationDriver"), "Expected SchemaValidationDriver error message, got: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testInsertColumnCommentBypass() throws SQLException {
+        // Block 'password' column
+        String url = "jdbc:schema[blockedColumns=password]:jdbc:mock:test";
+        Properties info = new Properties();
+        Connection conn = DriverManager.getConnection(url, info);
+        Statement stmt = conn.createStatement();
+
+        // This should be blocked
+        String bypassSql = "INSERT INTO users /* comment */ (password) VALUES ('secret')";
+
+        try {
+            stmt.execute(bypassSql);
+            fail("Should have thrown SQLException for blocked INSERT column with comment");
+        } catch (SQLException e) {
+            assertTrue(e.getMessage().contains("SchemaValidationDriver"));
+        }
+    }
+}


### PR DESCRIPTION
### 🛡️ Sentinel: Harden SQL security filters against comment-based bypasses

#### 🚨 Severity: HIGH
Regex-based SQL filters in PJDBC could be bypassed by inserting SQL comments (`/*...*/` or `--...`) before or between keywords, as the original regexes only accounted for whitespace.

#### 💡 Vulnerability
SQL proxy drivers like `ReadonlyDriver` and `SchemaValidationDriver` used simple whitespace matching (`^\\s*` or `\\s+`) to detect blocked keywords. An attacker could bypass these checks by using comments, which are semantically whitespace in SQL but not matched by `\\s`.

#### 🎯 Impact
- **ReadonlyDriver Bypass**: Unauthorized DML/DDL operations could be executed on supposedly read-only connections.
- **SchemaValidation Bypass**: Unauthorized access to sensitive tables or columns could be achieved.

#### 🔧 Fix
- Introduced `org.pjdbc.util.SqlPatterns` to provide shared, robust regex components (`PREFIX`, `SEP`, `PREFIX_COMPONENT`) that explicitly match both whitespace and SQL comments.
- Updated `ReadonlyDriver`, `SchemaValidationDriver`, and `WhereTransformer` to use these patterns combined with `Pattern.DOTALL` for reliable keyword detection.
- Fixed a minor conformance test failure related to wildcard parameters.

#### ✅ Verification
- Added `src/test/java/org/pjdbc/drivers/ReadonlyBypassTest.java` covering block, line, multi-line, and nested comments.
- Added `src/test/java/org/pjdbc/drivers/SchemaValidationBypassTest.java` covering table and column bypasses via comments.
- Ran full test suite (`mvn test -Pfast`) with 100% pass rate (941 tests).

---
*PR created automatically by Jules for task [15137090452386163388](https://jules.google.com/task/15137090452386163388) started by @davidaventimiglia-professional*