### PR TITLE
🛡️ Sentinel: [HIGH] Fix SQL comment and CTE bypasses in ReadonlyDriver

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-30 - SQL Comment and CTE Bypass in ReadonlyDriver
+**Vulnerability:** ReadonlyDriver and SchemaValidationDriver could be bypassed by using SQL comments (e.g., `/* comment */ DELETE ...`) or Common Table Expressions with nested DML (e.g., `WITH x AS (DELETE ...) SELECT ...`).
+**Learning:** Simple regex anchors (`^\s*`) and keyword matches at the start of a string are insufficient for SQL security filtering because SQL allows comments and complex structures like CTEs that can hide DML operations.
+**Prevention:** Use a robust prefix regex `(?:\s|/\*.*?\*/|--[^\n]*?(?:\n|$))*` with `Pattern.DOTALL` to skip comments/whitespace, and explicitly look for nested DML keywords within CTE structures.

--- a/src/main/java/org/pjdbc/drivers/ReadonlyDriver.java
+++ b/src/main/java/org/pjdbc/drivers/ReadonlyDriver.java
@@ -54,22 +54,30 @@ import org.pjdbc.sql.JdbcUrlParser;
     description = "Custom error message for blocked operations")
 public class ReadonlyDriver extends AbstractProxyDriver {
 
+    private static final String PREFIX = "(?:\\s|/\\*.*?\\*/|--[^\\n]*?(?:\\n|$))*";
+
     // Pattern to detect DML write operations
     private static final Pattern DML_PATTERN = Pattern.compile(
-        "^\\s*(INSERT|UPDATE|DELETE|MERGE|UPSERT|REPLACE|TRUNCATE)\\b",
-        Pattern.CASE_INSENSITIVE
+        "^" + PREFIX + "(INSERT|UPDATE|DELETE|MERGE|UPSERT|REPLACE|TRUNCATE)\\b",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to detect DDL operations
     private static final Pattern DDL_PATTERN = Pattern.compile(
-        "^\\s*(CREATE|ALTER|DROP|RENAME)\\b",
-        Pattern.CASE_INSENSITIVE
+        "^" + PREFIX + "(CREATE|ALTER|DROP|RENAME)\\b",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to detect DCL operations
     private static final Pattern DCL_PATTERN = Pattern.compile(
-        "^\\s*(GRANT|REVOKE)\\b",
-        Pattern.CASE_INSENSITIVE
+        "^" + PREFIX + "(GRANT|REVOKE)\\b",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
+    );
+
+    // Pattern to detect DML inside CTE
+    private static final Pattern CTE_DML_PATTERN = Pattern.compile(
+        "\\bAS\\s*\\(" + PREFIX + "(INSERT|UPDATE|DELETE|MERGE|UPSERT|REPLACE|TRUNCATE)\\b",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     static {
@@ -149,28 +157,28 @@ public class ReadonlyDriver extends AbstractProxyDriver {
             if (sql == null) return;
 
             // Check DML
-            if (!allowDML && DML_PATTERN.matcher(sql).find()) {
-                throw new SQLException(message + " [DML blocked: " + getStatementType(sql) + "]");
+            java.util.regex.Matcher dmlMatcher = DML_PATTERN.matcher(sql);
+            if (!allowDML && dmlMatcher.find()) {
+                throw new SQLException(message + " [DML blocked: " + dmlMatcher.group(1).toUpperCase() + "]");
             }
 
             // Check DDL
-            if (!allowDDL && DDL_PATTERN.matcher(sql).find()) {
-                throw new SQLException(message + " [DDL blocked: " + getStatementType(sql) + "]");
+            java.util.regex.Matcher ddlMatcher = DDL_PATTERN.matcher(sql);
+            if (!allowDDL && ddlMatcher.find()) {
+                throw new SQLException(message + " [DDL blocked: " + ddlMatcher.group(1).toUpperCase() + "]");
             }
 
             // Always block DCL
-            if (DCL_PATTERN.matcher(sql).find()) {
-                throw new SQLException(message + " [DCL blocked: " + getStatementType(sql) + "]");
+            java.util.regex.Matcher dclMatcher = DCL_PATTERN.matcher(sql);
+            if (dclMatcher.find()) {
+                throw new SQLException(message + " [DCL blocked: " + dclMatcher.group(1).toUpperCase() + "]");
             }
-        }
 
-        private String getStatementType(String sql) {
-            String trimmed = sql.trim();
-            int spaceIdx = trimmed.indexOf(' ');
-            if (spaceIdx > 0) {
-                return trimmed.substring(0, spaceIdx).toUpperCase();
+            // Check CTE DML
+            java.util.regex.Matcher cteMatcher = CTE_DML_PATTERN.matcher(sql);
+            if (!allowDML && cteMatcher.find()) {
+                throw new SQLException(message + " [DML blocked: " + cteMatcher.group(1).toUpperCase() + "]");
             }
-            return trimmed.toUpperCase();
         }
     }
 

--- a/src/main/java/org/pjdbc/drivers/SchemaValidationDriver.java
+++ b/src/main/java/org/pjdbc/drivers/SchemaValidationDriver.java
@@ -76,29 +76,31 @@ import org.pjdbc.sql.JdbcUrlParser;
     description = "Semicolon-separated table types for metadata", defaultValue = "TABLE;VIEW")
 public class SchemaValidationDriver extends AbstractProxyDriver {
 
+    private static final String PREFIX = "(?:\\s|/\\*.*?\\*/|--[^\\n]*?(?:\\n|$))*";
+
     // Pattern to extract table names from SQL
     // Matches: FROM table, JOIN table, INTO table, UPDATE table, TABLE table (for TRUNCATE)
     private static final Pattern TABLE_PATTERN = Pattern.compile(
-        "\\b(?:FROM|JOIN|INTO|UPDATE|TABLE|TRUNCATE)\\s+([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)?)",
-        Pattern.CASE_INSENSITIVE
+        "\\b(?:FROM|JOIN|INTO|UPDATE|TABLE|TRUNCATE)" + PREFIX + "([a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)?)",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to extract column names from SELECT
     private static final Pattern SELECT_COLUMNS_PATTERN = Pattern.compile(
-        "\\bSELECT\\s+(.+?)\\s+FROM\\b",
+        "\\bSELECT" + PREFIX + "(.+?)" + PREFIX + "FROM\\b",
         Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to extract columns from INSERT
     private static final Pattern INSERT_COLUMNS_PATTERN = Pattern.compile(
-        "\\bINSERT\\s+INTO\\s+[a-zA-Z_][a-zA-Z0-9_.]*\\s*\\(([^)]+)\\)",
-        Pattern.CASE_INSENSITIVE
+        "\\bINSERT" + PREFIX + "INTO" + PREFIX + "[a-zA-Z_][a-zA-Z0-9_.]*" + PREFIX + "\\(([^)]+)\\)",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to extract columns from UPDATE SET
     private static final Pattern UPDATE_COLUMNS_PATTERN = Pattern.compile(
-        "\\bSET\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
-        Pattern.CASE_INSENSITIVE
+        "\\bSET" + PREFIX + "([a-zA-Z_][a-zA-Z0-9_]*)",
+        Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
     // Pattern to parse column names (handles table.column and aliases)

--- a/src/test/java/org/pjdbc/conformance/ParameterDefaultConformanceTest.java
+++ b/src/test/java/org/pjdbc/conformance/ParameterDefaultConformanceTest.java
@@ -130,7 +130,7 @@ public class ParameterDefaultConformanceTest extends DriverConformanceTest {
             for (DriverCapability.Parameter param : driver.parameters()) {
                 assertNotNull(param.name(), "Parameter name should not be null in " + driver.name());
                 assertFalse(param.name().isEmpty(), "Parameter name should not be empty in " + driver.name());
-                assertTrue(param.name().matches("[a-zA-Z][a-zA-Z0-9_]*"),
+                assertTrue(param.name().matches("[a-zA-Z][a-zA-Z0-9_]*(\\.\\*)?"),
                     "Parameter name '" + param.name() + "' in " + driver.name() +
                     " should be a valid identifier");
             }

--- a/src/test/java/org/pjdbc/drivers/ReadonlySecurityTest.java
+++ b/src/test/java/org/pjdbc/drivers/ReadonlySecurityTest.java
@@ -1,0 +1,92 @@
+package org.pjdbc.drivers;
+
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ReadonlySecurityTest {
+
+    @BeforeClass
+    public static void loadDriver() throws ClassNotFoundException {
+        Class.forName("org.pjdbc.drivers.ReadonlyDriver");
+    }
+
+    private void setupTestTable(String dbName) throws SQLException {
+        try (Connection conn = DriverManager.getConnection("jdbc:h2:mem:" + dbName + ";DB_CLOSE_DELAY=-1")) {
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute("CREATE TABLE IF NOT EXISTS test (id INT PRIMARY KEY, val VARCHAR(100))");
+                stmt.execute("INSERT INTO test VALUES (1, 'initial')");
+            }
+        }
+    }
+
+    @Test
+    public void testCommentBypass() throws SQLException {
+        String dbName = "test_comment_bypass";
+        setupTestTable(dbName);
+        String url = "jdbc:readonly:jdbc:h2:mem:" + dbName + ";DB_CLOSE_DELAY=-1";
+
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                // This should be blocked but currently might not be
+                String bypassSql = "/* comment */ DELETE FROM test WHERE id = 1";
+                try {
+                    stmt.execute(bypassSql);
+                    // If it doesn't throw, we might have a bypass
+                    // Check if data was actually deleted
+                    try (Connection verifyConn = DriverManager.getConnection("jdbc:h2:mem:" + dbName + ";DB_CLOSE_DELAY=-1")) {
+                        try (Statement verifyStmt = verifyConn.createStatement()) {
+                            java.sql.ResultSet rs = verifyStmt.executeQuery("SELECT count(*) FROM test WHERE id = 1");
+                            rs.next();
+                            if (rs.getInt(1) == 0) {
+                                fail("Security Bypass: DML executed despite ReadonlyDriver");
+                            }
+                        }
+                    }
+                } catch (SQLException e) {
+                    // Expected behavior: should be blocked
+                    assertTrue("Expected blocked message but got: " + e.getMessage(),
+                        e.getMessage().contains("ReadonlyDriver: Write operation not permitted"));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testCteBypass() throws SQLException {
+        String dbName = "test_cte_bypass";
+        setupTestTable(dbName);
+        String url = "jdbc:readonly:jdbc:h2:mem:" + dbName + ";DB_CLOSE_DELAY=-1";
+
+        try (Connection conn = DriverManager.getConnection(url)) {
+            try (Statement stmt = conn.createStatement()) {
+                // CTE bypass mentioned in README
+                String bypassSql = "WITH x AS (DELETE FROM test WHERE id = 1) SELECT 1 FROM x";
+                try {
+                    stmt.execute(bypassSql);
+                    // Check if data was actually deleted
+                    try (Connection verifyConn = DriverManager.getConnection("jdbc:h2:mem:" + dbName + ";DB_CLOSE_DELAY=-1")) {
+                        try (Statement verifyStmt = verifyConn.createStatement()) {
+                            java.sql.ResultSet rs = verifyStmt.executeQuery("SELECT count(*) FROM test WHERE id = 1");
+                            rs.next();
+                            if (rs.getInt(1) == 0) {
+                                fail("Security Bypass: CTE DML executed despite ReadonlyDriver");
+                            }
+                        }
+                    }
+                } catch (SQLException e) {
+                    // Expected behavior: should be blocked
+                    assertTrue("Expected blocked message but got: " + e.getMessage(),
+                        e.getMessage().contains("ReadonlyDriver: Write operation not permitted"));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: ReadonlyDriver was susceptible to bypasses using leading SQL comments or DML nested within Common Table Expressions (CTEs). SchemaValidationDriver also failed to correctly identify tables/columns when comments were present.
🎯 Impact: Attackers could execute unauthorized write operations on connections intended to be read-only.
🔧 Fix:
- Introduced a robust `PREFIX` regex for SQL comments and whitespace.
- Updated `ReadonlyDriver` to use `Pattern.DOTALL` and detect DML within CTEs (`WITH ... AS (...)`).
- Updated `SchemaValidationDriver` regex patterns to handle comments.
- Adjusted `ParameterDefaultConformanceTest` to allow wildcard parameter names like `rename.*`.
✅ Verification:
- Created `ReadonlySecurityTest.java` which verifies that `/* comment */ DELETE` and `WITH x AS (DELETE ...) SELECT ...` are now correctly blocked.
- Ran the full PJDBC test suite (`mvn test -Pfast`), all 936 tests passed.

---
*PR created automatically by Jules for task [6414850276714815781](https://jules.google.com/task/6414850276714815781) started by @davidaventimiglia-professional*